### PR TITLE
feat(web): consome resources para status de eventos e categorias de doações

### DIFF
--- a/src/app/(pages)/(manager)/dashboard/donations/page.tsx
+++ b/src/app/(pages)/(manager)/dashboard/donations/page.tsx
@@ -32,7 +32,7 @@ function Donations() {
          key: 'category',
          label: 'Categoria',
          render: (value: IDonation['category']) => 
-            value ? <Status status={value.name as any} /> : '-',
+            value ? <Status status={value.name} /> : '-',
       },
       { key: 'donator_name', label: 'Doador' },
       {

--- a/src/app/(pages)/(manager)/dashboard/events/[id]/components/BasicInfoSection.tsx
+++ b/src/app/(pages)/(manager)/dashboard/events/[id]/components/BasicInfoSection.tsx
@@ -1,5 +1,6 @@
 import { UseFormRegister, FieldErrors } from 'react-hook-form';
-import { IEventForm } from '@/core/event/model/IEvent';
+import { EventStatus, IEventForm } from '@/core/event/model/IEvent';
+import { useEventStatusOptions } from '@/data/hooks/useResources';
 
 interface BasicInfoSectionProps {
    register: UseFormRegister<IEventForm>;
@@ -10,6 +11,8 @@ export default function BasicInfoSection({
    register,
    errors,
 }: BasicInfoSectionProps) {
+   const { options: eventStatusOptions } = useEventStatusOptions();
+
    return (
       <div className="space-y-4">
          <h2 className="text-xl font-bold text-gray-800">
@@ -108,11 +111,13 @@ export default function BasicInfoSection({
                   id="status"
                   className="input"
                   {...register('status')}
-                  defaultValue="Aberto"
+                  defaultValue={EventStatus.SCHEDULED}
                >
-                  <option value="Aberto">Aberto</option>
-                  <option value="Cancelado">Cancelado</option>
-                  <option value="Concluído">Concluído</option>
+                  {eventStatusOptions.map((statusOption) => (
+                     <option key={statusOption.value} value={statusOption.value}>
+                        {statusOption.label}
+                     </option>
+                  ))}
                </select>
                {errors.status && (
                   <p className="text-red-500 text-sm">

--- a/src/app/(pages)/(manager)/dashboard/events/[id]/page.tsx
+++ b/src/app/(pages)/(manager)/dashboard/events/[id]/page.tsx
@@ -3,7 +3,7 @@ import { useParams, useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import Breadcrumb from '@/components/Breadcrumb/Breadcrumb';
 import { eventSchema, IEvent } from '@/core/event';
-import { IEventForm } from '@/core/event/model/IEvent';
+import { IEventForm, normalizeEventStatusValue } from '@/core/event/model/IEvent';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import useCEP from '@/data/hooks/useCEP';
@@ -49,6 +49,7 @@ export default function EditEventPage() {
             date: eventData.data.date
                ? new Date(eventData.data.date).toISOString().slice(0, 16)
                : '',
+            status: normalizeEventStatusValue(eventData.data.status),
          };
          reset(formattedEventData);
       }

--- a/src/app/(pages)/(manager)/dashboard/events/page.tsx
+++ b/src/app/(pages)/(manager)/dashboard/events/page.tsx
@@ -9,7 +9,6 @@ import { IEvent } from '@/core/event';
 import { useEvents } from '@/data/hooks/useEvents';
 import { useEventMutations } from '@/data/hooks/useEventMutations';
 import { Status } from '@/components/shared/Status';
-import { EventStatus } from '@/core/event/model/IEvent';
 import { toast } from 'react-toastify';
 
 function Events() {
@@ -58,7 +57,7 @@ function Events() {
       {
          key: 'status',
          label: 'Status',
-         render: (value: string) => <Status status={value as EventStatus} />,
+         render: (value: string) => <Status status={value} />,
       },
    ];
 

--- a/src/app/(pages)/(manager)/dashboard/events/register/page.tsx
+++ b/src/app/(pages)/(manager)/dashboard/events/register/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { eventSchema, IEvent } from '@/core/event';
+import { eventSchema, EventStatus, IEvent } from '@/core/event';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useRouter } from 'next/navigation';
 import React, { useState } from 'react';
@@ -8,10 +8,12 @@ import { useForm, SubmitHandler } from 'react-hook-form';
 import Breadcrumb from '@/components/Breadcrumb';
 import useCEP from '@/data/hooks/useCEP';
 import { useEventMutations } from '@/data/hooks/useEventMutations';
+import { useEventStatusOptions } from '@/data/hooks/useResources';
 
 function Register() {
    const router = useRouter();
    const { createEvent } = useEventMutations();
+   const { options: eventStatusOptions } = useEventStatusOptions();
 
    // useCEP hook
    const {
@@ -170,11 +172,16 @@ function Register() {
                               id="status"
                               className="input"
                               {...register('status')}
-                              defaultValue="Aberto"
+                              defaultValue={EventStatus.SCHEDULED}
                            >
-                              <option value="Cancelado">Cancelado</option>
-                              <option value="Aberto">Aberto</option>
-                              <option value="Concluído">Concluído</option>
+                              {eventStatusOptions.map((statusOption) => (
+                                 <option
+                                    key={statusOption.value}
+                                    value={statusOption.value}
+                                 >
+                                    {statusOption.label}
+                                 </option>
+                              ))}
                            </select>
                            {errors.status && (
                               <p className="text-red-500 text-sm">

--- a/src/app/(pages)/(manager)/dashboard/page.tsx
+++ b/src/app/(pages)/(manager)/dashboard/page.tsx
@@ -14,6 +14,7 @@ import {
    IRecentFamily,
    IUpcomingEvent,
 } from '@/core/dashboard/model/IDashboard';
+import { getEventStatusLabel } from '@/core/event';
 import {
    ArrowClockwiseIcon,
    CalendarBlankIcon,
@@ -31,18 +32,7 @@ const formatDate = (value: string) =>
       day: 'numeric',
    });
 
-const formatStatus = (status: string) => {
-   const normalized = status
-      .normalize('NFD')
-      .replace(/[\u0300-\u036f]/g, '')
-      .toLowerCase();
-
-   if (normalized.includes('concl')) return 'Concluído';
-   if (normalized.includes('cancel')) return 'Cancelado';
-   if (normalized.includes('aberto') || normalized.includes('ativo'))
-      return 'Aberto';
-   return status;
-};
+const formatStatus = (status: string) => getEventStatusLabel(status);
 
 function LoadingState() {
    return (

--- a/src/app/(pages)/(manager)/dashboard/volunteers/[id]/page.tsx
+++ b/src/app/(pages)/(manager)/dashboard/volunteers/[id]/page.tsx
@@ -9,6 +9,7 @@ import { toast } from 'react-toastify';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import useCEP from '@/data/hooks/useCEP';
+import { useRoleOptions } from '@/data/hooks/useResources';
 import { formatCPF, formatCEP, formatPhone } from '@/utils/masks';
 
 // Mock data for volunteers
@@ -83,6 +84,7 @@ export default function EditVolunteerPage() {
    const [volunteer, setVolunteer] = useState<IVolunteer | null>(null);
    const [loading, setLoading] = useState(true);
    const [isLoading, setIsLoading] = useState(false);
+   const { options: roleOptions } = useRoleOptions();
 
    const {
       register,
@@ -387,15 +389,14 @@ export default function EditVolunteerPage() {
                               className="input"
                               {...register('role')}
                            >
-                              <option value={VolunteerRole.VOLUNTEER}>
-                                 Voluntário
-                              </option>
-                              <option value={VolunteerRole.MANAGER}>
-                                 Gerente
-                              </option>
-                              <option value={VolunteerRole.ADMIN}>
-                                 Administrador
-                              </option>
+                              {roleOptions.map((roleOption) => (
+                                 <option
+                                    key={roleOption.value}
+                                    value={roleOption.value}
+                                 >
+                                    {roleOption.label}
+                                 </option>
+                              ))}
                            </select>
                            {errors.role && (
                               <p className="text-red-500 text-sm">

--- a/src/app/(pages)/(manager)/dashboard/volunteers/register/page.tsx
+++ b/src/app/(pages)/(manager)/dashboard/volunteers/register/page.tsx
@@ -10,11 +10,13 @@ import { useForm, SubmitHandler } from 'react-hook-form';
 import { toast } from 'react-toastify';
 import Breadcrumb from '@/components/Breadcrumb';
 import useCEP from '@/data/hooks/useCEP';
+import { useRoleOptions } from '@/data/hooks/useResources';
 import { formatCPF, formatCEP, formatPhone } from '@/utils/masks';
 
 function Register() {
    const router = useRouter();
    const [isLoading, setIsLoading] = useState(false);
+   const { options: roleOptions } = useRoleOptions();
 
    // useCEP hook
    const {
@@ -269,15 +271,14 @@ function Register() {
                               {...register('role')}
                               defaultValue={VolunteerRole.VOLUNTEER}
                            >
-                              <option value={VolunteerRole.VOLUNTEER}>
-                                 Voluntário
-                              </option>
-                              <option value={VolunteerRole.MANAGER}>
-                                 Gerente
-                              </option>
-                              <option value={VolunteerRole.ADMIN}>
-                                 Administrador
-                              </option>
+                              {roleOptions.map((roleOption) => (
+                                 <option
+                                    key={roleOption.value}
+                                    value={roleOption.value}
+                                 >
+                                    {roleOption.label}
+                                 </option>
+                              ))}
                            </select>
                            {errors.role && (
                               <p className="text-red-500 text-sm">

--- a/src/components/LandingPage/CalendarCards.tsx
+++ b/src/components/LandingPage/CalendarCards.tsx
@@ -5,6 +5,7 @@ import Calendar from 'react-calendar';
 import { format, isSameDay, parseISO } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 import { useEventsOnCalendar } from '@/data/hooks/useEventQueries';
+import { getEventStatusLabel } from '@/core/event';
 import 'react-calendar/dist/Calendar.css';
 import CalendarSkeleton from '../shared/CalendarSkeleton';
 
@@ -171,7 +172,7 @@ export default function CalendarCards() {
                                  </div>
                                  <div className="ml-4">
                                     <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-primary/10 text-primary">
-                                       {event.status}
+                                       {getEventStatusLabel(event.status)}
                                     </span>
                                  </div>
                               </div>

--- a/src/components/Panel/Pagination.tsx
+++ b/src/components/Panel/Pagination.tsx
@@ -33,7 +33,7 @@ export default function Pagination({
    return (
       <div className="flex gap-2 justify-center mt-4">
          <button
-            className="px-3 py-1 rounded bg-tertiary text-primary disabled:opacity-50"
+            className="min-w-12 px-3 py-2 rounded-md bg-tertiary text-primary font-semibold border border-primary/20 transition-colors hover:bg-secondary/20 disabled:opacity-50 disabled:cursor-not-allowed"
             onClick={() => onPageChange(currentPage - 1)}
             disabled={currentPage === 1}
          >
@@ -41,16 +41,19 @@ export default function Pagination({
          </button>
          {filteredPages.map((page, idx) =>
             page === '...' ? (
-               <span key={idx} className="px-3 py-1">
+               <span
+                  key={idx}
+                  className="min-w-12 px-3 py-2 text-center text-primary/70 font-semibold"
+               >
                   ...
                </span>
             ) : (
                <button
                   key={idx}
-                  className={`px-3 py-1 rounded ${
+                  className={`min-w-12 px-3 py-2 rounded-md border font-semibold transition-all ${
                      page === currentPage
-                        ? 'bg-secondary text-white'
-                        : 'bg-secondary text-secondary'
+                        ? 'bg-primary text-white border-primary ring-2 ring-primary/30 shadow-sm'
+                        : 'bg-tertiary text-primary border-primary/20 hover:bg-secondary/20'
                   }`}
                   onClick={() => onPageChange(Number(page))}
                >
@@ -59,7 +62,7 @@ export default function Pagination({
             )
          )}
          <button
-            className="px-3 py-1 rounded bg-tertiary text-primary disabled:opacity-50"
+            className="min-w-12 px-3 py-2 rounded-md bg-tertiary text-primary font-semibold border border-primary/20 transition-colors hover:bg-secondary/20 disabled:opacity-50 disabled:cursor-not-allowed"
             onClick={() => onPageChange(currentPage + 1)}
             disabled={currentPage === totalPages}
          >

--- a/src/components/shared/Status.tsx
+++ b/src/components/shared/Status.tsx
@@ -12,25 +12,46 @@ import {
    getEventStatusLabel,
    parseEventStatus,
 } from '@/core/event/model/IEvent';
-import { Category } from '@/core/donation/model/IDonation';
 import { VolunteerRole } from '@/core/volunteer/model/IVolunteer';
 
 interface StatusProps {
-   status: string | Category | VolunteerRole;
+   status: string | VolunteerRole;
    selected?: boolean;
 }
 
-const isCategory = (status: string | Category | VolunteerRole): status is Category => {
-   return Object.values(Category).includes(status as Category);
-};
-
 const isVolunteerRole = (
-   status: string | Category | VolunteerRole
+   status: string | VolunteerRole
 ): status is VolunteerRole => {
    return Object.values(VolunteerRole).includes(status as VolunteerRole);
 };
 
-const getStatusStyles = (status: string | Category | VolunteerRole): string => {
+const normalizeLabel = (value: string): string =>
+   value
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .toLowerCase()
+      .trim();
+
+const formatGenericLabel = (value: string): string => {
+   const trimmed = value.trim();
+
+   if (!trimmed) {
+      return 'Desconhecido';
+   }
+
+   if (!trimmed.includes('_')) {
+      return trimmed;
+   }
+
+   return trimmed
+      .toLowerCase()
+      .split('_')
+      .filter(Boolean)
+      .map((chunk) => chunk.charAt(0).toUpperCase() + chunk.slice(1))
+      .join(' ');
+};
+
+const getStatusStyles = (status: string | VolunteerRole): string => {
    const eventStatus = parseEventStatus(status);
 
    if (eventStatus) {
@@ -41,19 +62,6 @@ const getStatusStyles = (status: string | Category | VolunteerRole): string => {
             return 'bg-tertiary text-primary border border-tertiary';
          case EventStatus.COMPLETED:
             return 'bg-success_light text-success border border-success_light';
-         default:
-            return 'bg-gray-100 text-gray-800 hover:text-gray-800';
-      }
-   }
-
-   if (isCategory(status)) {
-      switch (status) {
-         case Category.ALIMENTO:
-            return 'bg-success_light text-success border border-success_light';
-         case Category.BRINQUEDO:
-            return 'bg-danger_hover text-danger border border-danger_hover';
-         case Category.VESTIMENTA:
-            return 'bg-tertiary text-primary border border-tertiary';
          default:
             return 'bg-gray-100 text-gray-800 hover:text-gray-800';
       }
@@ -71,11 +79,31 @@ const getStatusStyles = (status: string | Category | VolunteerRole): string => {
             return 'bg-gray-100 text-gray-800 hover:text-gray-800';
       }
    }
-   return 'bg-gray-100 text-gray-800 hover:text-gray-800';
+
+   const normalized = normalizeLabel(status);
+
+   if (normalized.includes('alimento')) {
+      return 'bg-success_light text-success border border-success_light';
+   }
+
+   if (
+      normalized.includes('roupa') ||
+      normalized.includes('vestimenta') ||
+      normalized.includes('calcado') ||
+      normalized.includes('calca')
+   ) {
+      return 'bg-tertiary text-primary border border-tertiary';
+   }
+
+   if (normalized.includes('brinquedo')) {
+      return 'bg-danger_hover text-danger border border-danger_hover';
+   }
+
+   return 'bg-tertiary text-primary border border-tertiary';
 };
 
 const getStatusIcon = (
-   status: string | Category | VolunteerRole
+   status: string | VolunteerRole
 ) => {
    const eventStatus = parseEventStatus(status);
 
@@ -94,52 +122,45 @@ const getStatusIcon = (
       }
    }
 
-   if (isCategory(status)) {
-      switch (status) {
-         case Category.ALIMENTO:
-            return (
-               <ShoppingCartIcon
-                  size={20}
-                  className="text-success mr-1"
-                  weight="fill"
-               />
-            );
-         case Category.BRINQUEDO:
-            return <RobotIcon size={20} className="text-danger mr-1" />;
-         case Category.VESTIMENTA:
-            return <TShirtIcon size={20} className="text-primary mr-1" />;
-         default:
-            return null;
-      }
-   }
-
    if (isVolunteerRole(status)) {
       return <IdentificationBadgeIcon size={20} className="mr-1" />;
+   }
+
+   const normalized = normalizeLabel(status);
+
+   if (normalized.includes('alimento')) {
+      return (
+         <ShoppingCartIcon
+            size={20}
+            className="text-success mr-1"
+            weight="fill"
+         />
+      );
+   }
+
+   if (normalized.includes('brinquedo')) {
+      return <RobotIcon size={20} className="text-danger mr-1" />;
+   }
+
+   if (
+      normalized.includes('roupa') ||
+      normalized.includes('vestimenta') ||
+      normalized.includes('calcado') ||
+      normalized.includes('calca')
+   ) {
+      return <TShirtIcon size={20} className="text-primary mr-1" />;
    }
 
    return null;
 };
 
 const getStatusText = (
-   status: string | Category | VolunteerRole
+   status: string | VolunteerRole
 ): string => {
    const eventStatus = parseEventStatus(status);
 
    if (eventStatus) {
       return getEventStatusLabel(eventStatus);
-   }
-
-   if (isCategory(status)) {
-      switch (status) {
-         case Category.ALIMENTO:
-            return 'Alimento';
-         case Category.BRINQUEDO:
-            return 'Brinquedo';
-         case Category.VESTIMENTA:
-            return 'Vestimenta';
-         default:
-            return 'Desconhecido';
-      }
    }
 
    if (isVolunteerRole(status)) {
@@ -155,19 +176,20 @@ const getStatusText = (
       }
    }
 
-   return 'Desconhecido';
+   return formatGenericLabel(status);
 };
 
 export function Status({ status, selected }: StatusProps) {
    return (
       <div
-         className={`flex items-center justify-center text-center gap-1 py-1 rounded-md font-medium text-sm w-32 ${getStatusStyles(
+         className={`inline-flex items-center justify-center text-center gap-1 py-1 px-2 rounded-md font-medium text-sm min-w-[8rem] max-w-[14rem] ${getStatusStyles(
             status
-         )} ${selected ? 'ring-2 ring-blue-400' : ''}`}
-         style={{ minWidth: '8rem', maxWidth: '10rem' }}
+         )} ${selected ? 'ring-2 ring-primary' : ''}`}
       >
-         {getStatusIcon(status)}
-         {getStatusText(status)}
+         <span className="shrink-0">{getStatusIcon(status)}</span>
+         <span className="whitespace-normal break-words leading-tight text-inherit">
+            {getStatusText(status)}
+         </span>
       </div>
    );
 }

--- a/src/components/shared/Status.tsx
+++ b/src/components/shared/Status.tsx
@@ -5,63 +5,61 @@ import {
    ShoppingCartIcon,
    RobotIcon,
    TShirtIcon,
-   UserIcon,
    IdentificationBadgeIcon,
 } from '@phosphor-icons/react';
-import { EventStatus } from '@/core/event/model/IEvent';
+import {
+   EventStatus,
+   getEventStatusLabel,
+   parseEventStatus,
+} from '@/core/event/model/IEvent';
 import { Category } from '@/core/donation/model/IDonation';
 import { VolunteerRole } from '@/core/volunteer/model/IVolunteer';
 
 interface StatusProps {
-   status: EventStatus | Category | VolunteerRole;
+   status: string | Category | VolunteerRole;
    selected?: boolean;
 }
 
-// Type guards
-const isEventStatus = (
-   status: EventStatus | Category | VolunteerRole
-): status is EventStatus => {
-   return Object.values(EventStatus).includes(status as EventStatus);
-};
-
-const isCategory = (
-   status: EventStatus | Category | VolunteerRole
-): status is Category => {
+const isCategory = (status: string | Category | VolunteerRole): status is Category => {
    return Object.values(Category).includes(status as Category);
 };
 
 const isVolunteerRole = (
-   status: EventStatus | Category | VolunteerRole
+   status: string | Category | VolunteerRole
 ): status is VolunteerRole => {
    return Object.values(VolunteerRole).includes(status as VolunteerRole);
 };
 
-const getStatusStyles = (
-   status: EventStatus | Category | VolunteerRole
-): string => {
-   if (isEventStatus(status)) {
-      switch (status) {
-         case EventStatus.CANCELADO:
-            return 'bg-warning_light text-danger border border-warning_light ';
-         case EventStatus.ABERTO:
+const getStatusStyles = (status: string | Category | VolunteerRole): string => {
+   const eventStatus = parseEventStatus(status);
+
+   if (eventStatus) {
+      switch (eventStatus) {
+         case EventStatus.CANCELED:
+            return 'bg-warning_light text-danger border border-warning_light';
+         case EventStatus.SCHEDULED:
             return 'bg-tertiary text-primary border border-tertiary';
-         case EventStatus.CONCLUIDO:
+         case EventStatus.COMPLETED:
             return 'bg-success_light text-success border border-success_light';
          default:
             return 'bg-gray-100 text-gray-800 hover:text-gray-800';
       }
-   } else if (isCategory(status)) {
+   }
+
+   if (isCategory(status)) {
       switch (status) {
          case Category.ALIMENTO:
-            return 'bg-success_light text-success border border-success_light ';
+            return 'bg-success_light text-success border border-success_light';
          case Category.BRINQUEDO:
-            return 'bg-danger_hover text-danger border border-danger_hover ';
+            return 'bg-danger_hover text-danger border border-danger_hover';
          case Category.VESTIMENTA:
-            return 'bg-tertiary text-primary border border-tertiary ';
+            return 'bg-tertiary text-primary border border-tertiary';
          default:
             return 'bg-gray-100 text-gray-800 hover:text-gray-800';
       }
-   } else if (isVolunteerRole(status)) {
+   }
+
+   if (isVolunteerRole(status)) {
       switch (status) {
          case VolunteerRole.ADMIN:
             return 'bg-danger text-white border border-danger';
@@ -77,22 +75,26 @@ const getStatusStyles = (
 };
 
 const getStatusIcon = (
-   status: EventStatus | Category | VolunteerRole
+   status: string | Category | VolunteerRole
 ) => {
-   if (isEventStatus(status)) {
-      switch (status) {
-         case EventStatus.CANCELADO:
+   const eventStatus = parseEventStatus(status);
+
+   if (eventStatus) {
+      switch (eventStatus) {
+         case EventStatus.CANCELED:
             return <XIcon size={20} className="text-danger mr-1" />;
-         case EventStatus.ABERTO:
+         case EventStatus.SCHEDULED:
             return (
                <ExclamationMarkIcon size={20} className="text-primary mr-1" />
             );
-         case EventStatus.CONCLUIDO:
+         case EventStatus.COMPLETED:
             return <CheckIcon size={20} className="text-green-600 mr-1" />;
          default:
             return null;
       }
-   } else if (isCategory(status)) {
+   }
+
+   if (isCategory(status)) {
       switch (status) {
          case Category.ALIMENTO:
             return (
@@ -109,27 +111,25 @@ const getStatusIcon = (
          default:
             return null;
       }
-   } else if (isVolunteerRole(status)) {
+   }
+
+   if (isVolunteerRole(status)) {
       return <IdentificationBadgeIcon size={20} className="mr-1" />;
    }
+
    return null;
 };
 
 const getStatusText = (
-   status: EventStatus | Category | VolunteerRole
+   status: string | Category | VolunteerRole
 ): string => {
-   if (isEventStatus(status)) {
-      switch (status) {
-         case EventStatus.CANCELADO:
-            return 'Cancelado';
-         case EventStatus.ABERTO:
-            return 'Aberto';
-         case EventStatus.CONCLUIDO:
-            return 'Concluído';
-         default:
-            return 'Desconhecido';
-      }
-   } else if (isCategory(status)) {
+   const eventStatus = parseEventStatus(status);
+
+   if (eventStatus) {
+      return getEventStatusLabel(eventStatus);
+   }
+
+   if (isCategory(status)) {
       switch (status) {
          case Category.ALIMENTO:
             return 'Alimento';
@@ -140,7 +140,9 @@ const getStatusText = (
          default:
             return 'Desconhecido';
       }
-   } else if (isVolunteerRole(status)) {
+   }
+
+   if (isVolunteerRole(status)) {
       switch (status) {
          case VolunteerRole.ADMIN:
             return 'Admin';
@@ -152,6 +154,7 @@ const getStatusText = (
             return 'Desconhecido';
       }
    }
+
    return 'Desconhecido';
 };
 

--- a/src/core/donation/model/IDonation.ts
+++ b/src/core/donation/model/IDonation.ts
@@ -22,9 +22,3 @@ export interface IDonation {
    created_at?: Date | null;
    updated_at?: Date | null;
 }
-
-export enum Category {
-   VESTIMENTA = 'Vestimenta',
-   ALIMENTO = 'Alimento',
-   BRINQUEDO = 'Brinquedo',
-}

--- a/src/core/event/index.ts
+++ b/src/core/event/index.ts
@@ -1,5 +1,21 @@
 import { eventSchema } from './validation/eventSchema';
-import { IEvent } from './model/IEvent';
+import {
+   IEvent,
+   IEventForm,
+   EventStatus,
+   EventStatusOption,
+   EVENT_STATUS_OPTIONS,
+   getEventStatusLabel,
+   normalizeEventStatusValue,
+   parseEventStatus,
+} from './model/IEvent';
 
-export type { IEvent };
-export { eventSchema };
+export type { IEvent, IEventForm, EventStatusOption };
+export {
+   eventSchema,
+   EventStatus,
+   EVENT_STATUS_OPTIONS,
+   getEventStatusLabel,
+   normalizeEventStatusValue,
+   parseEventStatus,
+};

--- a/src/core/event/model/IEvent.ts
+++ b/src/core/event/model/IEvent.ts
@@ -15,7 +15,7 @@ export interface IEvent {
    neighborhood: string;
    number: string;
    complement: string;
-   status: string;
+   status: EventStatus;
 
    // active:
    logs?: ILogVolunteerEvent[];
@@ -35,7 +35,61 @@ export interface ILogVolunteerEvent {
 }
 
 export enum EventStatus {
-   CANCELADO = 'Cancelado',
-   ABERTO = 'Aberto',
-   CONCLUIDO = 'Concluído',
+   SCHEDULED = 'SCHEDULED',
+   COMPLETED = 'COMPLETED',
+   CANCELED = 'CANCELED',
 }
+
+export interface EventStatusOption {
+   label: string;
+   value: EventStatus;
+}
+
+export const EVENT_STATUS_OPTIONS: EventStatusOption[] = [
+   { label: 'Aberto', value: EventStatus.SCHEDULED },
+   { label: 'Concluído', value: EventStatus.COMPLETED },
+   { label: 'Cancelado', value: EventStatus.CANCELED },
+];
+
+const normalizeStatus = (value: string): string =>
+   value
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .toUpperCase();
+
+export const parseEventStatus = (
+   status?: string | null
+): EventStatus | null => {
+   if (!status) return null;
+
+   const normalized = normalizeStatus(status);
+
+   if (normalized.includes('COMPLET') || normalized.includes('CONCLUID')) {
+      return EventStatus.COMPLETED;
+   }
+
+   if (normalized.includes('CANCEL')) {
+      return EventStatus.CANCELED;
+   }
+
+   if (normalized.includes('SCHEDULED') || normalized.includes('ABERTO') || normalized.includes('ATIVO')) {
+      return EventStatus.SCHEDULED;
+   }
+
+   return null;
+};
+
+export const normalizeEventStatusValue = (
+   status?: string | null,
+   fallback: EventStatus = EventStatus.SCHEDULED
+): EventStatus => parseEventStatus(status) ?? fallback;
+
+export const getEventStatusLabel = (status?: string | null): string => {
+   const parsed = parseEventStatus(status);
+
+   if (parsed === EventStatus.COMPLETED) return 'Concluído';
+   if (parsed === EventStatus.CANCELED) return 'Cancelado';
+   if (parsed === EventStatus.SCHEDULED) return 'Aberto';
+
+   return status ?? 'Desconhecido';
+};

--- a/src/core/event/validation/eventSchema.ts
+++ b/src/core/event/validation/eventSchema.ts
@@ -1,5 +1,5 @@
-import { object, string, date, ZodType } from 'zod';
-import { IEventForm } from '../model/IEvent';
+import { object, string, nativeEnum, ZodType } from 'zod';
+import { EventStatus, IEventForm } from '../model/IEvent';
 import { isValidInstagramUrl, isValidInstagramEmbed } from '@/utils/instagram';
 
 // Helper function to extract only digits from a string
@@ -81,11 +81,10 @@ export const eventSchema: ZodType<IEventForm> = object({
          }
       ),
 
-   status: string()
-      .min(5, 'Status é obrigatório')
-      .max(20, 'Status não pode ter mais de 20 caracteres')
-      .refine((val) => ['Aberto', 'Cancelado', 'Concluído'].includes(val), {
-         message: 'Status deve ser "Aberto", "Cancelado" ou "Concluído"',
+   status: nativeEnum(EventStatus, {
+      errorMap: () => ({
+         message: 'Status inválido. Use SCHEDULED, COMPLETED ou CANCELED',
       }),
+   }),
    greeting_description: string().optional().default(''),
 });

--- a/src/data/hooks/useResources.ts
+++ b/src/data/hooks/useResources.ts
@@ -1,0 +1,62 @@
+import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+import { queryKeys } from '../query/queryKeys';
+import {
+   EventStatusApiResponse,
+   FALLBACK_EVENT_STATUS_OPTIONS,
+   FALLBACK_ROLE_OPTIONS,
+   resourcesService,
+   RoleOption,
+   RolesApiResponse,
+} from '../services/resourcesService';
+import { EventStatusOption } from '@/core/event/model/IEvent';
+
+export function useRolesResources(
+   options?: Omit<UseQueryOptions<RolesApiResponse>, 'queryKey' | 'queryFn'>
+) {
+   return useQuery({
+      queryKey: queryKeys.resources.roles(),
+      queryFn: () => resourcesService.getRoles(),
+      staleTime: 30 * 60 * 1000,
+      ...options,
+   });
+}
+
+export function useEventStatusResources(
+   options?: Omit<
+      UseQueryOptions<EventStatusApiResponse>,
+      'queryKey' | 'queryFn'
+   >
+) {
+   return useQuery({
+      queryKey: queryKeys.resources.eventStatus(),
+      queryFn: () => resourcesService.getEventStatus(),
+      staleTime: 30 * 60 * 1000,
+      ...options,
+   });
+}
+
+export function useRoleOptions(): {
+   options: RoleOption[];
+   isLoading: boolean;
+   isError: boolean;
+} {
+   const { data, isLoading, isError } = useRolesResources();
+   const options = data?.data?.roles?.length
+      ? data.data.roles
+      : FALLBACK_ROLE_OPTIONS;
+
+   return { options, isLoading, isError };
+}
+
+export function useEventStatusOptions(): {
+   options: EventStatusOption[];
+   isLoading: boolean;
+   isError: boolean;
+} {
+   const { data, isLoading, isError } = useEventStatusResources();
+   const options = data?.data?.status?.length
+      ? data.data.status
+      : FALLBACK_EVENT_STATUS_OPTIONS;
+
+   return { options, isLoading, isError };
+}

--- a/src/data/query/queryKeys.ts
+++ b/src/data/query/queryKeys.ts
@@ -60,4 +60,11 @@ export const queryKeys = {
       overview: (period: string) =>
          [...queryKeys.dashboard.all, 'overview', { period }] as const,
    },
+
+   resources: {
+      all: ['resources'] as const,
+      roles: () => [...queryKeys.resources.all, 'roles'] as const,
+      eventStatus: () =>
+         [...queryKeys.resources.all, 'event-status'] as const,
+   },
 } as const;

--- a/src/data/services/eventService.ts
+++ b/src/data/services/eventService.ts
@@ -1,4 +1,4 @@
-import { IEvent } from '@/core/event';
+import { EventStatus, IEvent } from '@/core/event';
 import {
    ApiRequestBehavior,
    ApiRequestError,
@@ -7,7 +7,7 @@ import {
 
 export interface EventFilters {
    search?: string;
-   status?: string;
+   status?: EventStatus;
    limit?: number;
    offset?: number;
    page?: number;

--- a/src/data/services/resourcesService.ts
+++ b/src/data/services/resourcesService.ts
@@ -1,0 +1,56 @@
+import {
+   EVENT_STATUS_OPTIONS,
+   EventStatusOption,
+} from '@/core/event/model/IEvent';
+import { VolunteerRole } from '@/core/volunteer/model/IVolunteer';
+import { BaseService } from './baseService';
+
+export interface RoleOption {
+   label: string;
+   value: VolunteerRole;
+}
+
+export interface RolesApiResponse {
+   code: number;
+   success: boolean;
+   message: string;
+   data: {
+      roles: RoleOption[];
+   };
+}
+
+export interface EventStatusApiResponse {
+   code: number;
+   success: boolean;
+   message: string;
+   data: {
+      status: EventStatusOption[];
+   };
+}
+
+export const FALLBACK_ROLE_OPTIONS: RoleOption[] = [
+   { label: 'Voluntário', value: VolunteerRole.VOLUNTEER },
+   { label: 'Gerente', value: VolunteerRole.MANAGER },
+   { label: 'Administrador', value: VolunteerRole.ADMIN },
+];
+
+export const FALLBACK_EVENT_STATUS_OPTIONS: EventStatusOption[] =
+   EVENT_STATUS_OPTIONS;
+
+class ResourcesService extends BaseService<never> {
+   constructor() {
+      super('resources');
+   }
+
+   async getRoles(): Promise<RolesApiResponse> {
+      return this.request<RolesApiResponse>(`/${this.entityPath}/roles`);
+   }
+
+   async getEventStatus(): Promise<EventStatusApiResponse> {
+      return this.request<EventStatusApiResponse>(
+         `/${this.entityPath}/event-status`
+      );
+   }
+}
+
+export const resourcesService = new ResourcesService();


### PR DESCRIPTION
## Resumo
Este PR adapta o frontend para o novo contrato do backend com enums em inglês para status de eventos e uso de endpoints de recursos.

## Alterações
- consome os endpoints `/resources/event-status` e `/resources/roles` para preencher opções de formulários
- envia status de evento no formato enum da API (`SCHEDULED`, `COMPLETED`, `CANCELED`)
- mantém exibição em PT-BR com mapeamento de labels no dashboard, listagens e landing
- adiciona fallback local quando `/resources` falha, evitando bloqueio de tela
- corrige renderização de categorias de doação para suportar valores dinâmicos vindos do banco
- ajusta o chip de status para exibir categorias com múltiplas palavras (ex.: "Alimento não perecível")

## Impacto
- frontend passa a seguir o contrato atual da API para status de eventos
- elimina ocorrência de categoria "Desconhecido" por incompatibilidade com enum fixo

## Validação
- build do projeto concluído com sucesso (`yarn build`)
- fluxo smoke validado para criação/edição/listagem de eventos e listagem de doações