### PR TITLE
[codex] Add frontend role permissions and layout fixes

### DIFF
--- a/src/app/(pages)/(manager)/dashboard/donations/page.tsx
+++ b/src/app/(pages)/(manager)/dashboard/donations/page.tsx
@@ -8,11 +8,15 @@ import Modal from '@/components/Modal/Modal';
 import { IDonation } from '@/core/donation/model/IDonation';
 import Status from '@/components/shared/Status';
 import { useDonations } from '@/data/hooks/donation/useDonations';
+import useAuth from '@/data/hooks/useAuth';
+import { canDeleteRecords } from '@/core/auth/permissions';
 
 function Donations() {
    const router = useRouter();
+   const { user } = useAuth();
    const [isDeleteModalOpen, setIsDeleteModalOpen] = useState<boolean>(false);
    const { donations, removeDonation } = useDonations();
+   const canDelete = canDeleteRecords(user?.role);
    const [selectedDonation, setSelectedDonation] = useState<IDonation | null>(
       null
    );
@@ -31,7 +35,7 @@ function Donations() {
       {
          key: 'category',
          label: 'Categoria',
-         render: (value: IDonation['category']) => 
+         render: (value: IDonation['category']) =>
             value ? <Status status={value.name} /> : '-',
       },
       { key: 'donator_name', label: 'Doador' },
@@ -83,17 +87,21 @@ function Donations() {
          onClick: handleEdit,
          className: '',
       },
-      {
-         key: 'delete',
-         label: 'Deletar',
-         icon: (
-            <div className="text-danger hover:text-white bg-danger_hover rounded-md p-2 hover:bg-danger">
-               <TrashIcon size={24} />
-            </div>
-         ),
-         onClick: handleDelete,
-         className: '',
-      },
+      ...(canDelete
+         ? [
+              {
+                 key: 'delete',
+                 label: 'Deletar',
+                 icon: (
+                    <div className="text-danger hover:text-white bg-danger_hover rounded-md p-2 hover:bg-danger">
+                       <TrashIcon size={24} />
+                    </div>
+                 ),
+                 onClick: handleDelete,
+                 className: '',
+              },
+           ]
+         : []),
    ];
 
    const onSearch = (value: string) => {
@@ -101,7 +109,7 @@ function Donations() {
    };
 
    return (
-      <div className="min-h-screen p-4 bg-gray-100">
+      <div className="min-h-full p-4 bg-gray-100">
          <div className="flex justify-between items-center mb-6">
             <Breadcrumb items={breadcrumbItems} />
             <button

--- a/src/app/(pages)/(manager)/dashboard/events/[id]/components/BasicInfoSection.tsx
+++ b/src/app/(pages)/(manager)/dashboard/events/[id]/components/BasicInfoSection.tsx
@@ -1,17 +1,24 @@
 import { UseFormRegister, FieldErrors } from 'react-hook-form';
-import { EventStatus, IEventForm } from '@/core/event/model/IEvent';
+import {
+   EventStatus,
+   EventStatusOption,
+   IEventForm,
+} from '@/core/event/model/IEvent';
 import { useEventStatusOptions } from '@/data/hooks/useResources';
 
 interface BasicInfoSectionProps {
    register: UseFormRegister<IEventForm>;
    errors: FieldErrors<IEventForm>;
+   statusOptions?: EventStatusOption[];
 }
 
 export default function BasicInfoSection({
    register,
    errors,
+   statusOptions,
 }: BasicInfoSectionProps) {
    const { options: eventStatusOptions } = useEventStatusOptions();
+   const resolvedStatusOptions = statusOptions ?? eventStatusOptions;
 
    return (
       <div className="space-y-4">
@@ -113,7 +120,7 @@ export default function BasicInfoSection({
                   {...register('status')}
                   defaultValue={EventStatus.SCHEDULED}
                >
-                  {eventStatusOptions.map((statusOption) => (
+                  {resolvedStatusOptions.map((statusOption) => (
                      <option key={statusOption.value} value={statusOption.value}>
                         {statusOption.label}
                      </option>

--- a/src/app/(pages)/(manager)/dashboard/events/[id]/page.tsx
+++ b/src/app/(pages)/(manager)/dashboard/events/[id]/page.tsx
@@ -3,7 +3,12 @@ import { useParams, useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import Breadcrumb from '@/components/Breadcrumb/Breadcrumb';
 import { eventSchema, IEvent } from '@/core/event';
-import { IEventForm, normalizeEventStatusValue } from '@/core/event/model/IEvent';
+import {
+   EVENT_STATUS_OPTIONS,
+   EventStatus,
+   IEventForm,
+   normalizeEventStatusValue,
+} from '@/core/event/model/IEvent';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import useCEP from '@/data/hooks/useCEP';
@@ -13,11 +18,24 @@ import BasicInfoSection from './components/BasicInfoSection';
 import AddressSection from './components/AddressSection';
 import SocialMediaSection from './components/SocialMediaSection';
 import LottieAnimation from '@/components/shared/LottieAnimation';
+import useAuth from '@/data/hooks/useAuth';
+import {
+   canCancelEvent,
+   canPublishEventInstagram,
+} from '@/core/auth/permissions';
 
 export default function EditEventPage() {
-   const params = useParams();
-   const router = useRouter();
-   const { updateEvent } = useEventMutations();
+	   const params = useParams();
+	   const router = useRouter();
+	   const { user } = useAuth();
+	   const {
+	      updateEvent,
+	      updateEventStatus,
+	      updateEventAttendance,
+	      updateEventInstagram,
+	   } = useEventMutations();
+	   const canPublishInstagram = canPublishEventInstagram(user?.role);
+	   const canUseAllStatuses = canCancelEvent(user?.role);
 
    const eventId = Array.isArray(params.id) ? params.id[0] : params.id;
    const { data: eventData, isLoading: loading, error } = useEventById(eventId);
@@ -75,24 +93,49 @@ export default function EditEventPage() {
       router.push('/dashboard/events');
    };
 
-   const submit: SubmitHandler<IEventForm> = async (data) => {
-      const apiData: IEvent = {
-         ...data,
-         date: new Date(data.date),
-      };
+	   const submit: SubmitHandler<IEventForm> = async (data) => {
+	      const apiData: IEvent = {
+	         ...data,
+	         date: new Date(data.date),
+	      };
 
-      updateEvent.mutate(
-         { id: eventId, event: apiData },
-         {
-            onSuccess: () => {
-               router.push('/dashboard/events');
-            },
-            onError: (error) => {
-               console.error('Erro ao atualizar evento:', error);
-            },
-         }
-      );
-   };
+	      try {
+	         await updateEvent.mutateAsync({ id: eventId, event: apiData });
+
+	         const currentStatus = normalizeEventStatusValue(event?.status);
+	         if (data.status && data.status !== currentStatus) {
+	            await updateEventStatus.mutateAsync({
+	               id: eventId,
+	               status: data.status,
+	            });
+	         }
+
+	         const attendance = Number(data.attendance ?? 0);
+	         if (
+	            Number.isFinite(attendance) &&
+	            attendance !== (event?.attendance ?? 0)
+	         ) {
+	            await updateEventAttendance.mutateAsync({
+	               id: eventId,
+	               attendance,
+	            });
+	         }
+
+	         if (
+	            canPublishInstagram &&
+	            data.embedded_instagram !== event?.embedded_instagram
+	         ) {
+	            await updateEventInstagram.mutateAsync({
+	               id: eventId,
+	               embedded_instagram: data.embedded_instagram,
+	            });
+	         }
+
+	         router.push('/dashboard/events');
+	      } catch (error) {
+	         console.error('Erro ao atualizar evento:', error);
+	      }
+	   };
 
    const event = eventData?.data;
    const breadcrumbItems = [
@@ -105,9 +148,23 @@ export default function EditEventPage() {
       return <LottieAnimation status="loading" />;
    }
 
-   if (error || !event) {
-      return <div>Evento não encontrado</div>;
-   }
+	   if (error || !event) {
+	      return <div>Evento não encontrado</div>;
+	   }
+
+	   const currentStatus = normalizeEventStatusValue(event.status);
+	   const statusOptions = canUseAllStatuses
+	      ? EVENT_STATUS_OPTIONS
+	      : EVENT_STATUS_OPTIONS.filter(
+	           (statusOption) =>
+	              statusOption.value === currentStatus ||
+	              statusOption.value === EventStatus.COMPLETED
+	        );
+	   const isSaving =
+	      updateEvent.isPending ||
+	      updateEventStatus.isPending ||
+	      updateEventAttendance.isPending ||
+	      updateEventInstagram.isPending;
 
    return (
       <div className="h-screen flex flex-col bg-gray-100">
@@ -120,29 +177,35 @@ export default function EditEventPage() {
          <div className="flex-1 overflow-y-auto p-4">
             <div className="p-6 bg-white rounded-3xl shadow-md border border-[#4AA1D3] space-y-6 pb-24">
                <form onSubmit={handleSubmit(submit)} className="space-y-6">
-                  <BasicInfoSection register={register} errors={errors} />
+	                  <BasicInfoSection
+	                     register={register}
+	                     errors={errors}
+	                     statusOptions={statusOptions}
+	                  />
                   <AddressSection
                      register={register}
                      errors={errors}
                      handleCepBlur={handleCepBlur}
                   />
-                  <SocialMediaSection register={register} errors={errors} />
+	                  {canPublishInstagram && (
+	                     <SocialMediaSection register={register} errors={errors} />
+	                  )}
 
                   <div className="flex justify-end gap-4 pt-4 sticky bottom-0 bg-white">
                      <button
                         type="button"
                         className="btn-danger w-32 text-white"
                         onClick={handleCancel}
-                        disabled={updateEvent.isPending}
+	                        disabled={isSaving}
                      >
                         Cancelar
                      </button>
                      <button
                         type="submit"
                         className="btn-primary w-32"
-                        disabled={updateEvent.isPending}
+	                        disabled={isSaving}
                      >
-                        {updateEvent.isPending ? 'Salvando...' : 'Salvar'}
+	                        {isSaving ? 'Salvando...' : 'Salvar'}
                      </button>
                   </div>
                </form>

--- a/src/app/(pages)/(manager)/dashboard/events/page.tsx
+++ b/src/app/(pages)/(manager)/dashboard/events/page.tsx
@@ -10,12 +10,17 @@ import { useEvents } from '@/data/hooks/useEvents';
 import { useEventMutations } from '@/data/hooks/useEventMutations';
 import { Status } from '@/components/shared/Status';
 import { toast } from 'react-toastify';
+import useAuth from '@/data/hooks/useAuth';
+import { canCreateEvents, canDeleteRecords } from '@/core/auth/permissions';
 
 function Events() {
-   const router = useRouter();
-   const { deleteEvent } = useEventMutations();
+	   const router = useRouter();
+	   const { user } = useAuth();
+	   const { deleteEvent } = useEventMutations();
    const [isDeleteModalOpen, setIsDeleteModalOpen] = useState<boolean>(false);
-   const { events } = useEvents();
+	   const { events } = useEvents();
+	   const canDelete = canDeleteRecords(user?.role);
+	   const canCreate = canCreateEvents(user?.role);
 
    const register = () => {
       router.push('/dashboard/events/register');
@@ -83,7 +88,7 @@ function Events() {
       });
    };
 
-   const actions = [
+	   const actions = [
       {
          key: 'edit',
          label: 'Editar',
@@ -95,18 +100,20 @@ function Events() {
          onClick: handleEdit,
          className: '',
       },
-      {
-         key: 'delete',
-         label: 'Deletar',
+	      ...(canDelete
+	         ? [{
+	         key: 'delete',
+	         label: 'Deletar',
          icon: (
             <div className="text-danger hover:text-white bg-danger_hover rounded-md p-2 hover:bg-danger">
                <TrashIcon size={24} />
             </div>
          ),
-         onClick: handleDelete,
-         className: '',
-      },
-   ];
+	         onClick: handleDelete,
+	         className: '',
+	      }]
+	         : []),
+	   ];
 
    const onSearch = (value: string) => {
       // TODO: Implement search/filter logic
@@ -116,12 +123,14 @@ function Events() {
       <div className="min-h-full p-4 bg-gray-100 pb-8">
          <div className="flex justify-between items-center mb-6">
             <Breadcrumb items={breadcrumbItems} />
-            <button
-               className="btn-primary justify-center flex text-nowrap w-32 text-center"
-               onClick={register}
-            >
-               Novo Evento
-            </button>
+            {canCreate && (
+               <button
+                  className="btn-primary justify-center flex text-nowrap w-32 text-center"
+                  onClick={register}
+               >
+                  Novo Evento
+               </button>
+            )}
          </div>
          <TableContainer
             title="Todos os Eventos"

--- a/src/app/(pages)/(manager)/dashboard/families/page.tsx
+++ b/src/app/(pages)/(manager)/dashboard/families/page.tsx
@@ -7,11 +7,15 @@ import { PencilIcon, TrashIcon } from '@phosphor-icons/react';
 import Modal from '@/components/Modal/Modal';
 import { IFamily } from '@/core/family/model/IFamily';
 import { useFamilies as useFamiliesContext } from '@/data/hooks/family/useFamilies';
+import useAuth from '@/data/hooks/useAuth';
+import { canDeleteRecords } from '@/core/auth/permissions';
 
 function Families() {
    const router = useRouter();
+   const { user } = useAuth();
    const [isDeleteModalOpen, setIsDeleteModalOpen] = useState<boolean>(false);
    const { families, removeFamily } = useFamiliesContext();
+   const canDelete = canDeleteRecords(user?.role);
 
    const register = () => {
       router.push('/dashboard/families/register');
@@ -81,17 +85,21 @@ function Families() {
          onClick: handleEdit,
          className: '',
       },
-      {
-         key: 'delete',
-         label: 'Deletar',
-         icon: (
-            <div className="text-danger hover:text-white bg-danger_hover rounded-md p-2 hover:bg-danger">
-               <TrashIcon size={24} />
-            </div>
-         ),
-         onClick: handleDelete,
-         className: '',
-      },
+      ...(canDelete
+         ? [
+              {
+                 key: 'delete',
+                 label: 'Deletar',
+                 icon: (
+                    <div className="text-danger hover:text-white bg-danger_hover rounded-md p-2 hover:bg-danger">
+                       <TrashIcon size={24} />
+                    </div>
+                 ),
+                 onClick: handleDelete,
+                 className: '',
+              },
+           ]
+         : []),
    ];
 
    const onSearch = (value: string) => {
@@ -99,7 +107,7 @@ function Families() {
    };
 
    return (
-      <div className="min-h-screen p-4 bg-gray-100">
+      <div className="min-h-full p-4 bg-gray-100">
          <div className="flex justify-between items-center mb-6">
             <Breadcrumb items={breadcrumbItems} />
             <button

--- a/src/app/(pages)/(manager)/dashboard/page.tsx
+++ b/src/app/(pages)/(manager)/dashboard/page.tsx
@@ -166,19 +166,19 @@ function Dashboard() {
    const overview = data?.data;
 
    const recentActivityItems = useMemo(
-      () =>
-         overview
-            ? [
-                 ...overview.lists.recent_donations.map((donation) => ({
-                    type: 'donation' as const,
-                    key: donation.id,
-                    createdAt: donation.created_at,
-                    payload: donation,
-                 })),
-                 ...overview.lists.recent_families.map((family) => ({
-                    type: 'family' as const,
-                    key: family.id,
-                    createdAt: family.created_at,
+	      () =>
+	         overview
+	            ? [
+	                 ...(overview.lists.recent_donations ?? []).map((donation) => ({
+	                    type: 'donation' as const,
+	                    key: donation.id,
+	                    createdAt: donation.created_at,
+	                    payload: donation,
+	                 })),
+	                 ...(overview.lists.recent_families ?? []).map((family) => ({
+	                    type: 'family' as const,
+	                    key: family.id,
+	                    createdAt: family.created_at,
                     payload: family,
                  })),
               ]
@@ -248,40 +248,43 @@ function Dashboard() {
                ))}
             </ListCard>
 
-            <ListCard
-               title="Cadastros recentes"
-               subtitle="Atividade"
-               emptyMessage="Nenhum cadastro recente disponível."
-               hasItems={recentActivityItems.length > 0}
-            >
-               {recentActivityItems.map((item) =>
-                  item.type === 'donation' ? (
-                     <div
-                        key={`${item.type}-${item.key}`}
-                        className="flex items-start gap-3"
-                     >
-                        <div className="rounded-xl bg-[#e9f3f9] p-2">
-                           <HandHeartIcon size={20} className="text-primary" />
-                        </div>
-                        <div className="flex-1">
-                           <RecentDonationItem donation={item.payload} />
-                        </div>
-                     </div>
-                  ) : (
-                     <div
-                        key={`${item.type}-${item.key}`}
-                        className="flex items-start gap-3"
-                     >
-                        <div className="rounded-xl bg-[#e9f3f9] p-2">
-                           <HouseLineIcon size={20} className="text-primary" />
-                        </div>
-                        <div className="flex-1">
-                           <RecentFamilyItem family={item.payload} />
-                        </div>
-                     </div>
-                  )
-               )}
-            </ListCard>
+	            {(overview.lists.recent_donations ||
+	               overview.lists.recent_families) && (
+	               <ListCard
+	                  title="Cadastros recentes"
+	                  subtitle="Atividade"
+	                  emptyMessage="Nenhum cadastro recente disponível."
+	                  hasItems={recentActivityItems.length > 0}
+	               >
+	                  {recentActivityItems.map((item) =>
+	                     item.type === 'donation' ? (
+	                        <div
+	                           key={`${item.type}-${item.key}`}
+	                           className="flex items-start gap-3"
+	                        >
+	                           <div className="rounded-xl bg-[#e9f3f9] p-2">
+	                              <HandHeartIcon size={20} className="text-primary" />
+	                           </div>
+	                           <div className="flex-1">
+	                              <RecentDonationItem donation={item.payload} />
+	                           </div>
+	                        </div>
+	                     ) : (
+	                        <div
+	                           key={`${item.type}-${item.key}`}
+	                           className="flex items-start gap-3"
+	                        >
+	                           <div className="rounded-xl bg-[#e9f3f9] p-2">
+	                              <HouseLineIcon size={20} className="text-primary" />
+	                           </div>
+	                           <div className="flex-1">
+	                              <RecentFamilyItem family={item.payload} />
+	                           </div>
+	                        </div>
+	                     )
+	                  )}
+	               </ListCard>
+	            )}
          </div>
 
          <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-3">

--- a/src/app/(pages)/(manager)/dashboard/volunteers/[id]/page.tsx
+++ b/src/app/(pages)/(manager)/dashboard/volunteers/[id]/page.tsx
@@ -1,90 +1,47 @@
 'use client';
+
 import { useParams, useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import Breadcrumb from '@/components/Breadcrumb/Breadcrumb';
 import { IVolunteer } from '@/core/volunteer';
 import { updateVolunteerFormSchema } from '@/core/volunteer/validation/volunteerSchema';
 import { VolunteerRole } from '@/core/volunteer/model/IVolunteer';
-import { toast } from 'react-toastify';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import useCEP from '@/data/hooks/useCEP';
 import { useRoleOptions } from '@/data/hooks/useResources';
 import { formatCPF, formatCEP, formatPhone } from '@/utils/masks';
+import { useEmployeeById } from '@/data/hooks/employee/useEmployeeQueries';
+import { useEmployeeMutations } from '@/data/hooks/employee/useEmployeeMutations';
+import useAuth from '@/data/hooks/useAuth';
+import {
+   canChangeEmployeePassword,
+   canChangeEmployeeRole,
+   canManageVolunteers,
+} from '@/core/auth/permissions';
+import LottieAnimation from '@/components/shared/LottieAnimation';
 
-// Mock data for volunteers
-const mockVolunteers: IVolunteer[] = [
-   {
-      id: '1',
-      name: 'João',
-      surname: 'Silva',
-      birth_date: new Date('1990-05-15'),
-      cpf: '56521667033',
-      email: 'joao.silva@email.com',
-      phone: '(11) 99999-9999',
-      password: 'hashedPassword123',
-      role: VolunteerRole.VOLUNTEER,
-      cep: '01234-567',
-      street: 'Rua das Flores',
-      neighborhood: 'Centro',
-      number: '123',
-      city: 'São Paulo',
-      uf: 'SP',
-      state: 'São Paulo',
-      complement: 'Apto 45',
-      created_at: new Date('2024-01-15'),
-      updated_at: new Date('2024-01-15'),
-   },
-   {
-      id: '2',
-      name: 'Maria',
-      surname: 'Santos',
-      birth_date: new Date('1985-08-22'),
-      cpf: '03841760031',
-      email: 'maria.santos@email.com',
-      phone: '(11) 88888-8888',
-      password: 'hashedPassword456',
-      role: VolunteerRole.MANAGER,
-      cep: '04567-890',
-      street: 'Avenida Paulista',
-      neighborhood: 'Bela Vista',
-      number: '456',
-      city: 'São Paulo',
-      uf: 'SP',
-      state: 'São Paulo',
-      created_at: new Date('2024-02-10'),
-      updated_at: new Date('2024-02-10'),
-   },
-   {
-      id: '3',
-      name: 'Pedro',
-      surname: 'Oliveira',
-      birth_date: new Date('1992-03-10'),
-      cpf: '34519557097',
-      email: 'pedro.oliveira@email.com',
-      phone: '(11) 77777-7777',
-      password: 'hashedPassword789',
-      role: VolunteerRole.ADMIN,
-      cep: '07890-123',
-      street: 'Rua Augusta',
-      neighborhood: 'Consolação',
-      number: '789',
-      city: 'São Paulo',
-      uf: 'SP',
-      state: 'São Paulo',
-      complement: 'Sala 101',
-      created_at: new Date('2024-03-05'),
-      updated_at: new Date('2024-03-05'),
-   },
-];
+function formatBirthDate(value?: Date | string) {
+   if (!value) return '';
+   return new Date(value).toISOString().slice(0, 10);
+}
 
 export default function EditVolunteerPage() {
    const params = useParams();
    const router = useRouter();
-   const [volunteer, setVolunteer] = useState<IVolunteer | null>(null);
-   const [loading, setLoading] = useState(true);
-   const [isLoading, setIsLoading] = useState(false);
-   const { options: roleOptions } = useRoleOptions();
+   const { user } = useAuth();
+   const { updateBasic, updateRole, updatePassword } = useEmployeeMutations();
+   const canManage = canManageVolunteers(user?.role);
+   const canEditRole = canChangeEmployeeRole(user?.role);
+   const canEditPassword = canChangeEmployeePassword(user?.role);
+   const { options: roleOptions } = useRoleOptions({ enabled: canManage });
+   const employeeId = Array.isArray(params.id) ? params.id[0] : params.id;
+   const { data, isLoading, error } = useEmployeeById(employeeId, canManage);
+   const volunteer = data?.data;
+   const [roleValue, setRoleValue] = useState<VolunteerRole>(
+      VolunteerRole.VOLUNTEER
+   );
+   const [newPassword, setNewPassword] = useState('');
 
    const {
       register,
@@ -107,38 +64,16 @@ export default function EditVolunteerPage() {
    const cepValue = watch('cep');
 
    useEffect(() => {
-      const fetchVolunteer = async () => {
-         try {
-            const volunteerData = mockVolunteers.find(
-               (volunteer) => volunteer.id === params.id
-            );
-            if (!volunteerData) {
-               toast.error('Voluntário não encontrado');
-               router.push('/dashboard/volunteers');
-               return;
-            }
-            setVolunteer(volunteerData);
+      if (!volunteer) return;
 
-            // Format birth_date for form input
-            const formattedVolunteerData = {
-               ...volunteerData,
-               birth_date: volunteerData.birth_date
-                  ? new Date(volunteerData.birth_date)
-                       .toISOString()
-                       .slice(0, 10)
-                  : '',
-            };
-            reset(formattedVolunteerData as any);
-         } catch (error) {
-            console.error('Error fetching volunteer:', error);
-            toast.error('Erro ao carregar voluntário');
-         } finally {
-            setLoading(false);
-         }
-      };
-
-      fetchVolunteer();
-   }, [params.id, router, reset]);
+      reset({
+         ...volunteer,
+         birth_date: formatBirthDate(volunteer.birth_date),
+         uf: volunteer.uf ?? '',
+         password: undefined,
+      });
+      setRoleValue(volunteer.role);
+   }, [reset, volunteer]);
 
    useEffect(() => {
       if (cepData) {
@@ -161,28 +96,27 @@ export default function EditVolunteerPage() {
       router.push('/dashboard/volunteers');
    };
 
-   const submit: SubmitHandler<IVolunteer> = async (data) => {
-      setIsLoading(true);
-      try {
-         const id = Array.isArray(params.id) ? params.id[0] : params.id;
-         const apiData: IVolunteer = {
-            ...data,
-            birth_date: new Date(data.birth_date),
-         };
+   const submit: SubmitHandler<IVolunteer> = async (formData) => {
+      updateBasic.mutate(
+         { id: employeeId, employee: formData },
+         {
+            onSuccess: () => router.push('/dashboard/volunteers'),
+         }
+      );
+   };
 
-         // Mock API call - simulate success
-         await new Promise((resolve) => setTimeout(resolve, 1000)); // Simulate API delay
+   const handleRoleUpdate = () => {
+      updateRole.mutate({ id: employeeId, role: roleValue });
+   };
 
-         toast.success('Voluntário atualizado com sucesso!');
-         router.push('/dashboard/volunteers');
-      } catch (error: any) {
-         toast.error(
-            error?.response?.data?.message ||
-               'Erro ao atualizar voluntário. Tente novamente.'
-         );
-      } finally {
-         setIsLoading(false);
-      }
+   const handlePasswordUpdate = () => {
+      if (!newPassword.trim()) return;
+      updatePassword.mutate(
+         { id: employeeId, data: { password: newPassword } },
+         {
+            onSuccess: () => setNewPassword(''),
+         }
+      );
    };
 
    const breadcrumbItems = [
@@ -195,11 +129,22 @@ export default function EditVolunteerPage() {
       },
    ];
 
-   if (loading) {
-      return <div>Carregando...</div>;
+   if (!canManage) {
+      return (
+         <div className="min-h-screen p-4 bg-gray-100">
+            <Breadcrumb items={breadcrumbItems} />
+            <div className="mt-6 rounded-xl bg-white p-6 shadow-sm">
+               Você não tem permissão para editar voluntários.
+            </div>
+         </div>
+      );
    }
 
-   if (!volunteer) {
+   if (isLoading) {
+      return <LottieAnimation status="loading" />;
+   }
+
+   if (error || !volunteer) {
       return <div>Voluntário não encontrado</div>;
    }
 
@@ -214,7 +159,6 @@ export default function EditVolunteerPage() {
          <div className="flex-1 overflow-y-auto p-4">
             <div className="p-6 bg-white rounded-3xl shadow-md border border-[#4AA1D3] space-y-6 pb-24">
                <form onSubmit={handleSubmit(submit)} className="space-y-6">
-                  {/* Informações Pessoais */}
                   <div className="space-y-4">
                      <h2 className="text-xl font-bold text-gray-800">
                         Informações Pessoais
@@ -224,32 +168,20 @@ export default function EditVolunteerPage() {
                            <label htmlFor="nome" className="font-semibold mb-1">
                               Nome <span className="text-red-500">*</span>
                            </label>
-                           <input
-                              type="text"
-                              id="nome"
-                              className="input"
-                              placeholder="Informe o nome"
-                              {...register('name')}
-                           />
+                           <input id="nome" className="input" {...register('name')} />
                            {errors.name && (
                               <p className="text-red-500 text-sm">
                                  {errors.name.message}
                               </p>
                            )}
                         </div>
-
                         <div className="flex flex-col flex-1 min-w-[250px]">
-                           <label
-                              htmlFor="sobrenome"
-                              className="font-semibold mb-1"
-                           >
+                           <label htmlFor="sobrenome" className="font-semibold mb-1">
                               Sobrenome <span className="text-red-500">*</span>
                            </label>
                            <input
-                              type="text"
                               id="sobrenome"
                               className="input"
-                              placeholder="Informe o sobrenome"
                               {...register('surname')}
                            />
                            {errors.surname && (
@@ -262,10 +194,7 @@ export default function EditVolunteerPage() {
 
                      <div className="flex flex-wrap gap-4">
                         <div className="flex flex-col flex-1 min-w-[250px]">
-                           <label
-                              htmlFor="nascimento"
-                              className="font-semibold mb-1"
-                           >
+                           <label htmlFor="nascimento" className="font-semibold mb-1">
                               Data de Nascimento{' '}
                               <span className="text-red-500">*</span>
                            </label>
@@ -281,21 +210,17 @@ export default function EditVolunteerPage() {
                               </p>
                            )}
                         </div>
-
                         <div className="flex flex-col flex-1 min-w-[250px]">
                            <label htmlFor="cpf" className="font-semibold mb-1">
                               CPF <span className="text-red-500">*</span>
                            </label>
                            <input
-                              type="text"
                               id="cpf"
                               className="input"
-                              placeholder="000.000.000-00"
                               {...register('cpf')}
-                              onChange={(e) => {
-                                 const formatted = formatCPF(e.target.value);
-                                 setValue('cpf', formatted);
-                              }}
+                              onChange={(event) =>
+                                 setValue('cpf', formatCPF(event.target.value))
+                              }
                               maxLength={14}
                            />
                            {errors.cpf && (
@@ -308,17 +233,13 @@ export default function EditVolunteerPage() {
 
                      <div className="flex flex-wrap gap-4">
                         <div className="flex flex-col flex-1 min-w-[250px]">
-                           <label
-                              htmlFor="email"
-                              className="font-semibold mb-1"
-                           >
+                           <label htmlFor="email" className="font-semibold mb-1">
                               Email <span className="text-red-500">*</span>
                            </label>
                            <input
                               type="email"
                               id="email"
                               className="input"
-                              placeholder="email@exemplo.com"
                               {...register('email')}
                            />
                            {errors.email && (
@@ -327,24 +248,17 @@ export default function EditVolunteerPage() {
                               </p>
                            )}
                         </div>
-
                         <div className="flex flex-col flex-1 min-w-[250px]">
-                           <label
-                              htmlFor="telefone"
-                              className="font-semibold mb-1"
-                           >
+                           <label htmlFor="telefone" className="font-semibold mb-1">
                               Telefone <span className="text-red-500">*</span>
                            </label>
                            <input
-                              type="tel"
                               id="telefone"
                               className="input"
-                              placeholder="(00) 00000-0000"
                               {...register('phone')}
-                              onChange={(e) => {
-                                 const formatted = formatPhone(e.target.value);
-                                 setValue('phone', formatted);
-                              }}
+                              onChange={(event) =>
+                                 setValue('phone', formatPhone(event.target.value))
+                              }
                               maxLength={15}
                            />
                            {errors.phone && (
@@ -354,86 +268,27 @@ export default function EditVolunteerPage() {
                            )}
                         </div>
                      </div>
-
-                     <div className="flex flex-wrap gap-4">
-                        <div className="flex flex-col flex-1 min-w-[250px]">
-                           <label
-                              htmlFor="senha"
-                              className="font-semibold mb-1"
-                           >
-                              Nova Senha
-                           </label>
-                           <input
-                              type="password"
-                              id="senha"
-                              className="input"
-                              placeholder="Deixe em branco para manter a atual"
-                              {...register('password')}
-                           />
-                           {errors.password && (
-                              <p className="text-red-500 text-sm">
-                                 {errors.password.message}
-                              </p>
-                           )}
-                        </div>
-
-                        <div className="flex flex-col flex-1 min-w-[250px]">
-                           <label
-                              htmlFor="funcao"
-                              className="font-semibold mb-1"
-                           >
-                              Função <span className="text-red-500">*</span>
-                           </label>
-                           <select
-                              id="funcao"
-                              className="input"
-                              {...register('role')}
-                           >
-                              {roleOptions.map((roleOption) => (
-                                 <option
-                                    key={roleOption.value}
-                                    value={roleOption.value}
-                                 >
-                                    {roleOption.label}
-                                 </option>
-                              ))}
-                           </select>
-                           {errors.role && (
-                              <p className="text-red-500 text-sm">
-                                 {errors.role.message}
-                              </p>
-                           )}
-                        </div>
-                     </div>
                   </div>
 
-                  {/* Endereço */}
                   <div className="space-y-4">
-                     <h2 className="text-xl font-bold text-gray-800">
-                        Endereço
-                     </h2>
+                     <h2 className="text-xl font-bold text-gray-800">Endereço</h2>
                      <div className="flex flex-wrap gap-4">
                         <div className="flex flex-col flex-1 min-w-[250px]">
                            <label htmlFor="cep" className="font-semibold mb-1">
                               CEP <span className="text-red-500">*</span>
                            </label>
                            <input
-                              type="text"
                               id="cep"
                               className="input"
-                              placeholder="00000-000"
                               {...register('cep')}
-                              onChange={(e) => {
-                                 const formatted = formatCEP(e.target.value);
-                                 setValue('cep', formatted);
-                              }}
+                              onChange={(event) =>
+                                 setValue('cep', formatCEP(event.target.value))
+                              }
                               onBlur={handleCepBlur}
                               maxLength={9}
                            />
                            {cepLoading && (
-                              <p className="text-blue-500 text-sm">
-                                 Buscando CEP...
-                              </p>
+                              <p className="text-blue-500 text-sm">Buscando CEP...</p>
                            )}
                            {cepError && (
                               <p className="text-red-500 text-sm">{cepError}</p>
@@ -444,21 +299,14 @@ export default function EditVolunteerPage() {
                               </p>
                            )}
                         </div>
-
                         <div className="flex flex-col flex-1 min-w-[250px]">
                            <label htmlFor="uf" className="font-semibold mb-1">
                               UF <span className="text-red-500">*</span>
                            </label>
                            <input
-                              type="text"
                               id="uf"
                               className="input"
-                              placeholder="UF"
                               {...register('uf')}
-                              value={cepData?.uf || watch('uf') || ''}
-                              onChange={(e) =>
-                                 setValue('uf', e.target.value.toUpperCase())
-                              }
                               maxLength={2}
                            />
                            {errors.uf && (
@@ -471,22 +319,13 @@ export default function EditVolunteerPage() {
 
                      <div className="flex flex-wrap gap-4">
                         <div className="flex flex-col flex-1 min-w-[250px]">
-                           <label
-                              htmlFor="estado"
-                              className="font-semibold mb-1"
-                           >
+                           <label htmlFor="estado" className="font-semibold mb-1">
                               Estado <span className="text-red-500">*</span>
                            </label>
                            <input
-                              type="text"
                               id="estado"
                               className="input"
-                              placeholder="Digite o estado"
                               {...register('state')}
-                              value={cepData?.estado || watch('state') || ''}
-                              onChange={(e) =>
-                                 setValue('state', e.target.value)
-                              }
                            />
                            {errors.state && (
                               <p className="text-red-500 text-sm">
@@ -494,23 +333,11 @@ export default function EditVolunteerPage() {
                               </p>
                            )}
                         </div>
-
                         <div className="flex flex-col flex-1 min-w-[250px]">
-                           <label
-                              htmlFor="cidade"
-                              className="font-semibold mb-1"
-                           >
+                           <label htmlFor="cidade" className="font-semibold mb-1">
                               Cidade <span className="text-red-500">*</span>
                            </label>
-                           <input
-                              type="text"
-                              id="cidade"
-                              className="input"
-                              placeholder="Digite a cidade"
-                              {...register('city')}
-                              value={cepData?.localidade || watch('city') || ''}
-                              onChange={(e) => setValue('city', e.target.value)}
-                           />
+                           <input id="cidade" className="input" {...register('city')} />
                            {errors.city && (
                               <p className="text-red-500 text-sm">
                                  {errors.city.message}
@@ -521,24 +348,13 @@ export default function EditVolunteerPage() {
 
                      <div className="flex flex-wrap gap-4">
                         <div className="flex flex-col flex-1 min-w-[250px]">
-                           <label
-                              htmlFor="bairro"
-                              className="font-semibold mb-1"
-                           >
+                           <label htmlFor="bairro" className="font-semibold mb-1">
                               Bairro <span className="text-red-500">*</span>
                            </label>
                            <input
-                              type="text"
                               id="bairro"
                               className="input"
-                              placeholder="Digite o bairro"
                               {...register('neighborhood')}
-                              value={
-                                 cepData?.bairro || watch('neighborhood') || ''
-                              }
-                              onChange={(e) =>
-                                 setValue('neighborhood', e.target.value)
-                              }
                            />
                            {errors.neighborhood && (
                               <p className="text-red-500 text-sm">
@@ -546,50 +362,14 @@ export default function EditVolunteerPage() {
                               </p>
                            )}
                         </div>
-                     </div>
-
-                     <div className="flex flex-wrap gap-4">
                         <div className="flex flex-col flex-1 min-w-[250px]">
                            <label htmlFor="rua" className="font-semibold mb-1">
                               Rua <span className="text-red-500">*</span>
                            </label>
-                           <input
-                              type="text"
-                              id="rua"
-                              className="input"
-                              placeholder="Logradouro"
-                              {...register('street')}
-                              value={
-                                 cepData?.logradouro || watch('street') || ''
-                              }
-                              onChange={(e) =>
-                                 setValue('street', e.target.value)
-                              }
-                           />
+                           <input id="rua" className="input" {...register('street')} />
                            {errors.street && (
                               <p className="text-red-500 text-sm">
-                                 {errors.street?.message}
-                              </p>
-                           )}
-                        </div>
-
-                        <div className="flex flex-col flex-1 min-w-[250px]">
-                           <label
-                              htmlFor="numero"
-                              className="font-semibold mb-1"
-                           >
-                              Número <span className="text-red-500">*</span>
-                           </label>
-                           <input
-                              type="text"
-                              id="numero"
-                              className="input"
-                              placeholder="Digite o número"
-                              {...register('number')}
-                           />
-                           {errors.number && (
-                              <p className="text-red-500 text-sm">
-                                 {errors.number?.message}
+                                 {errors.street.message}
                               </p>
                            )}
                         </div>
@@ -597,26 +377,28 @@ export default function EditVolunteerPage() {
 
                      <div className="flex flex-wrap gap-4">
                         <div className="flex flex-col flex-1 min-w-[250px]">
-                           <label
-                              htmlFor="complemento"
-                              className="font-semibold mb-1"
-                           >
+                           <label htmlFor="numero" className="font-semibold mb-1">
+                              Número <span className="text-red-500">*</span>
+                           </label>
+                           <input
+                              id="numero"
+                              className="input"
+                              {...register('number')}
+                           />
+                           {errors.number && (
+                              <p className="text-red-500 text-sm">
+                                 {errors.number.message}
+                              </p>
+                           )}
+                        </div>
+                        <div className="flex flex-col flex-1 min-w-[250px]">
+                           <label htmlFor="complemento" className="font-semibold mb-1">
                               Complemento
                            </label>
                            <input
-                              type="text"
                               id="complemento"
                               className="input"
-                              placeholder="Bloco, apartamento..."
                               {...register('complement')}
-                              value={
-                                 cepData?.complemento ||
-                                 watch('complement') ||
-                                 ''
-                              }
-                              onChange={(e) =>
-                                 setValue('complement', e.target.value)
-                              }
                            />
                         </div>
                      </div>
@@ -627,19 +409,93 @@ export default function EditVolunteerPage() {
                         type="button"
                         className="btn-danger w-32 text-white"
                         onClick={handleCancel}
-                        disabled={isLoading}
+                        disabled={updateBasic.isPending}
                      >
                         Cancelar
                      </button>
                      <button
                         type="submit"
                         className="btn-primary w-32"
-                        disabled={isLoading}
+                        disabled={updateBasic.isPending}
                      >
-                        {isLoading ? 'Salvando...' : 'Salvar'}
+                        {updateBasic.isPending ? 'Salvando...' : 'Salvar'}
                      </button>
                   </div>
                </form>
+
+               {(canEditRole || canEditPassword) && (
+                  <div className="space-y-4 border-t border-gray-200 pt-6">
+                     <h2 className="text-xl font-bold text-gray-800">
+                        Ações administrativas
+                     </h2>
+                     <div className="flex flex-wrap gap-4">
+                        {canEditRole && (
+                           <div className="flex flex-col flex-1 min-w-[250px]">
+                              <label htmlFor="funcao" className="font-semibold mb-1">
+                                 Função
+                              </label>
+                              <div className="flex gap-3">
+                                 <select
+                                    id="funcao"
+                                    className="input"
+                                    value={roleValue}
+                                    onChange={(event) =>
+                                       setRoleValue(event.target.value as VolunteerRole)
+                                    }
+                                 >
+                                    {roleOptions.map((roleOption) => (
+                                       <option
+                                          key={roleOption.value}
+                                          value={roleOption.value}
+                                       >
+                                          {roleOption.label}
+                                       </option>
+                                    ))}
+                                 </select>
+                                 <button
+                                    type="button"
+                                    className="btn-primary w-32"
+                                    onClick={handleRoleUpdate}
+                                    disabled={updateRole.isPending}
+                                 >
+                                    Atualizar
+                                 </button>
+                              </div>
+                           </div>
+                        )}
+
+                        {canEditPassword && (
+                           <div className="flex flex-col flex-1 min-w-[250px]">
+                              <label htmlFor="senha" className="font-semibold mb-1">
+                                 Nova senha
+                              </label>
+                              <div className="flex gap-3">
+                                 <input
+                                    type="password"
+                                    id="senha"
+                                    className="input"
+                                    value={newPassword}
+                                    onChange={(event) =>
+                                       setNewPassword(event.target.value)
+                                    }
+                                    placeholder="Nova senha"
+                                 />
+                                 <button
+                                    type="button"
+                                    className="btn-primary w-32"
+                                    onClick={handlePasswordUpdate}
+                                    disabled={
+                                       updatePassword.isPending || !newPassword.trim()
+                                    }
+                                 >
+                                    Atualizar
+                                 </button>
+                              </div>
+                           </div>
+                        )}
+                     </div>
+                  </div>
+               )}
             </div>
          </div>
       </div>

--- a/src/app/(pages)/(manager)/dashboard/volunteers/page.tsx
+++ b/src/app/(pages)/(manager)/dashboard/volunteers/page.tsx
@@ -1,87 +1,34 @@
 'use client';
+
 import TableContainer from '@/components/Panel/TableContainer';
 import Breadcrumb from '@/components/Breadcrumb/Breadcrumb';
 import { useRouter } from 'next/navigation';
 import React, { useState } from 'react';
 import { PencilIcon, TrashIcon } from '@phosphor-icons/react';
 import Modal from '@/components/Modal/Modal';
-import { toast } from 'react-toastify';
 import { IVolunteer } from '@/core/volunteer';
 import { VolunteerRole } from '@/core/volunteer/model/IVolunteer';
 import { Status } from '@/components/shared/Status';
-
-// Mock data for volunteers
-const mockVolunteers: IVolunteer[] = [
-   {
-      id: '1',
-      name: 'João',
-      surname: 'Silva',
-      birth_date: new Date('1990-05-15'),
-      cpf: '12345678901',
-      email: 'joao.silva@email.com',
-      phone: '(11) 99999-9999',
-      password: 'hashedPassword123',
-      role: VolunteerRole.VOLUNTEER,
-      cep: '01234-567',
-      street: 'Rua das Flores',
-      neighborhood: 'Centro',
-      number: '123',
-      city: 'São Paulo',
-      uf: 'SP',
-      state: 'São Paulo',
-      complement: 'Apto 45',
-      created_at: new Date('2024-01-15'),
-      updated_at: new Date('2024-01-15'),
-   },
-   {
-      id: '2',
-      name: 'Maria',
-      surname: 'Santos',
-      birth_date: new Date('1985-08-22'),
-      cpf: '98765432100',
-      email: 'maria.santos@email.com',
-      phone: '(11) 88888-8888',
-      password: 'hashedPassword456',
-      role: VolunteerRole.MANAGER,
-      cep: '04567-890',
-      street: 'Avenida Paulista',
-      neighborhood: 'Bela Vista',
-      number: '456',
-      city: 'São Paulo',
-      uf: 'SP',
-      state: 'São Paulo',
-      created_at: new Date('2024-02-10'),
-      updated_at: new Date('2024-02-10'),
-   },
-   {
-      id: '3',
-      name: 'Pedro',
-      surname: 'Oliveira',
-      birth_date: new Date('1992-03-10'),
-      cpf: '11122233344',
-      email: 'pedro.oliveira@email.com',
-      phone: '(11) 77777-7777',
-      password: 'hashedPassword789',
-      role: VolunteerRole.ADMIN,
-      cep: '07890-123',
-      street: 'Rua Augusta',
-      neighborhood: 'Consolação',
-      number: '789',
-      city: 'São Paulo',
-      uf: 'SP',
-      state: 'São Paulo',
-      complement: 'Sala 101',
-      created_at: new Date('2024-03-05'),
-      updated_at: new Date('2024-03-05'),
-   },
-];
+import useAuth from '@/data/hooks/useAuth';
+import {
+   canDeleteEmployees,
+   canManageVolunteers,
+} from '@/core/auth/permissions';
+import { useEmployees } from '@/data/hooks/employee/useEmployeeQueries';
+import { useEmployeeMutations } from '@/data/hooks/employee/useEmployeeMutations';
 
 function Volunteers() {
    const router = useRouter();
+   const { user } = useAuth();
+   const canManage = canManageVolunteers(user?.role);
+   const canDelete = canDeleteEmployees(user?.role);
+   const { data, isLoading } = useEmployees(canManage);
+   const { deleteEmployee } = useEmployeeMutations();
    const [isDeleteModalOpen, setIsDeleteModalOpen] = useState<boolean>(false);
-   const [volunteers, setVolunteers] = useState<IVolunteer[]>(mockVolunteers);
    const [selectedVolunteer, setSelectedVolunteer] =
       useState<IVolunteer | null>(null);
+
+   const volunteers = data?.data ?? [];
 
    const register = () => {
       router.push('/dashboard/volunteers/register');
@@ -96,7 +43,7 @@ function Volunteers() {
       {
          key: 'created_at',
          label: 'Data de cadastro',
-         render: (value: Date) =>
+         render: (value: Date | string) =>
             value
                ? new Date(value).toLocaleDateString('pt-BR', {
                     year: 'numeric',
@@ -108,7 +55,7 @@ function Volunteers() {
       {
          key: 'name',
          label: 'Nome',
-         render: (value: string, volunteer: IVolunteer) =>
+         render: (_value: string, volunteer: IVolunteer) =>
             `${volunteer.name} ${volunteer.surname}`,
       },
       { key: 'email', label: 'Email' },
@@ -131,18 +78,14 @@ function Volunteers() {
    };
 
    const handleDeleteConfirm = async () => {
-      try {
-         // Mock delete - remove from local state
-         setVolunteers((prev) =>
-            prev.filter((v) => v.id !== selectedVolunteer?.id)
-         );
-         toast.success('Voluntário excluído com sucesso!');
-         setIsDeleteModalOpen(false);
-         setSelectedVolunteer(null);
-      } catch (error) {
-         toast.error('Erro ao excluir voluntário');
-         console.error('Erro ao excluir voluntário:', error);
-      }
+      if (!selectedVolunteer?.id) return;
+
+      deleteEmployee.mutate(selectedVolunteer.id, {
+         onSuccess: () => {
+            setIsDeleteModalOpen(false);
+            setSelectedVolunteer(null);
+         },
+      });
    };
 
    const actions = [
@@ -157,35 +100,37 @@ function Volunteers() {
          onClick: handleEdit,
          className: '',
       },
-      {
-         key: 'delete',
-         label: 'Deletar',
-         icon: (
-            <div className="text-danger hover:text-white bg-danger_hover rounded-md p-2 hover:bg-danger">
-               <TrashIcon size={24} />
-            </div>
-         ),
-         onClick: handleDelete,
-         className: '',
-      },
+      ...(canDelete
+         ? [
+              {
+                 key: 'delete',
+                 label: 'Deletar',
+                 icon: (
+                    <div className="text-danger hover:text-white bg-danger_hover rounded-md p-2 hover:bg-danger">
+                       <TrashIcon size={24} />
+                    </div>
+                 ),
+                 onClick: handleDelete,
+                 className: '',
+              },
+           ]
+         : []),
    ];
 
    const onSearch = (value: string) => {
-      // Mock search functionality
-      if (!value.trim()) {
-         setVolunteers(mockVolunteers);
-         return;
-      }
-
-      const filtered = mockVolunteers.filter(
-         (volunteer) =>
-            volunteer.name.toLowerCase().includes(value.toLowerCase()) ||
-            volunteer.surname.toLowerCase().includes(value.toLowerCase()) ||
-            volunteer.email.toLowerCase().includes(value.toLowerCase()) ||
-            volunteer.city.toLowerCase().includes(value.toLowerCase())
-      );
-      setVolunteers(filtered);
+      // A busca local será substituída por filtro de API quando o endpoint suportar search.
    };
+
+   if (!canManage) {
+      return (
+         <div className="min-h-screen p-4 bg-gray-100">
+            <Breadcrumb items={breadcrumbItems} />
+            <div className="mt-6 rounded-xl bg-white p-6 shadow-sm">
+               Você não tem permissão para gerenciar voluntários.
+            </div>
+         </div>
+      );
+   }
 
    return (
       <div className="min-h-screen p-4 bg-gray-100">
@@ -199,7 +144,7 @@ function Volunteers() {
             </button>
          </div>
          <TableContainer
-            title="Todos os Voluntários"
+            title={isLoading ? 'Carregando voluntários...' : 'Todos os Voluntários'}
             columns={columns}
             data={volunteers}
             actions={actions}
@@ -220,11 +165,16 @@ function Volunteers() {
                   <button
                      onClick={() => setIsDeleteModalOpen(false)}
                      className="btn-secondary"
+                     disabled={deleteEmployee.isPending}
                   >
                      Cancelar
                   </button>
-                  <button onClick={handleDeleteConfirm} className="btn-danger">
-                     Excluir
+                  <button
+                     onClick={handleDeleteConfirm}
+                     className="btn-danger"
+                     disabled={deleteEmployee.isPending}
+                  >
+                     {deleteEmployee.isPending ? 'Excluindo...' : 'Excluir'}
                   </button>
                </div>
             </div>

--- a/src/app/(pages)/(manager)/dashboard/volunteers/register/page.tsx
+++ b/src/app/(pages)/(manager)/dashboard/volunteers/register/page.tsx
@@ -12,11 +12,21 @@ import Breadcrumb from '@/components/Breadcrumb';
 import useCEP from '@/data/hooks/useCEP';
 import { useRoleOptions } from '@/data/hooks/useResources';
 import { formatCPF, formatCEP, formatPhone } from '@/utils/masks';
+import useAuth from '@/data/hooks/useAuth';
+import {
+   canChangeEmployeeRole,
+   canManageVolunteers,
+} from '@/core/auth/permissions';
+import { useEmployeeMutations } from '@/data/hooks/employee/useEmployeeMutations';
 
 function Register() {
-   const router = useRouter();
-   const [isLoading, setIsLoading] = useState(false);
-   const { options: roleOptions } = useRoleOptions();
+	   const router = useRouter();
+	   const { user } = useAuth();
+	   const [isLoading, setIsLoading] = useState(false);
+	   const { createEmployee } = useEmployeeMutations();
+	   const canManage = canManageVolunteers(user?.role);
+	   const canSelectRole = canChangeEmployeeRole(user?.role);
+	   const { options: roleOptions } = useRoleOptions({ enabled: canManage });
 
    // useCEP hook
    const {
@@ -65,22 +75,67 @@ function Register() {
       router.push('/dashboard/volunteers');
    };
 
-   const submit: SubmitHandler<IVolunteer> = async (data) => {
-      setIsLoading(true);
-      try {
-         // Mock API call - simulate success
-         await new Promise((resolve) => setTimeout(resolve, 1000)); // Simulate API delay
-         toast.success('Voluntário cadastrado com sucesso!');
-         router.push('/dashboard/volunteers');
-      } catch (error: any) {
-         toast.error(
-            error?.response?.data?.message ||
-               'Erro ao cadastrar voluntário. Tente novamente.'
-         );
-      } finally {
-         setIsLoading(false);
-      }
-   };
+	   const submit: SubmitHandler<IVolunteer> = async (data) => {
+	      setIsLoading(true);
+	      try {
+	         createEmployee.mutate(
+	            {
+	               ...data,
+	               role: canSelectRole ? data.role : VolunteerRole.VOLUNTEER,
+	            },
+	            {
+	               onSuccess: () => router.push('/dashboard/volunteers'),
+	               onSettled: () => setIsLoading(false),
+	            }
+	         );
+	      } catch (error: any) {
+	         toast.error(
+	            error?.response?.data?.message ||
+	               'Erro ao cadastrar voluntário. Tente novamente.'
+	         );
+	         setIsLoading(false);
+	      }
+	   };
+
+	   if (!canManage) {
+	      return (
+	         <div className="min-h-screen p-4 bg-gray-100">
+	            <Breadcrumb items={breadcrumbItems} />
+	            <div className="mt-6 rounded-xl bg-white p-6 shadow-sm">
+	               Você não tem permissão para cadastrar voluntários.
+	            </div>
+	         </div>
+	      );
+	   }
+
+	   const roleField = canSelectRole ? (
+	      <div className="flex flex-col flex-1 min-w-[250px]">
+	         <label htmlFor="funcao" className="font-semibold mb-1">
+	            Função <span className="text-red-500">*</span>
+	         </label>
+	         <select
+	            id="funcao"
+	            className="input"
+	            {...register('role')}
+	            defaultValue={VolunteerRole.VOLUNTEER}
+	         >
+	            {roleOptions.map((roleOption) => (
+	               <option key={roleOption.value} value={roleOption.value}>
+	                  {roleOption.label}
+	               </option>
+	            ))}
+	         </select>
+	         {errors.role && (
+	            <p className="text-red-500 text-sm">{errors.role.message}</p>
+	         )}
+	      </div>
+	   ) : (
+	      <input
+	         type="hidden"
+	         value={VolunteerRole.VOLUNTEER}
+	         {...register('role')}
+	      />
+	   );
 
    return (
       <div className="h-screen flex flex-col bg-gray-100">
@@ -258,34 +313,7 @@ function Register() {
                            )}
                         </div>
 
-                        <div className="flex flex-col flex-1 min-w-[250px]">
-                           <label
-                              htmlFor="funcao"
-                              className="font-semibold mb-1"
-                           >
-                              Função <span className="text-red-500">*</span>
-                           </label>
-                           <select
-                              id="funcao"
-                              className="input"
-                              {...register('role')}
-                              defaultValue={VolunteerRole.VOLUNTEER}
-                           >
-                              {roleOptions.map((roleOption) => (
-                                 <option
-                                    key={roleOption.value}
-                                    value={roleOption.value}
-                                 >
-                                    {roleOption.label}
-                                 </option>
-                              ))}
-                           </select>
-                           {errors.role && (
-                              <p className="text-red-500 text-sm">
-                                 {errors.role.message}
-                              </p>
-                           )}
-                        </div>
+                        {roleField}
                      </div>
                   </div>
 

--- a/src/components/Dashboard/SummaryCards.tsx
+++ b/src/components/Dashboard/SummaryCards.tsx
@@ -53,7 +53,8 @@ export function SummaryCards({ summary }: SummaryCardsProps) {
             <CalendarIcon size={28} weight="duotone" className="text-primary" />
          ),
       },
-      {
+      ...(summary.active_employees !== undefined && summary.employees_by_role
+         ? [{
          title: 'Funcionários ativos',
          value: summary.active_employees,
          helper: `A ${summary.employees_by_role.ADMIN} | G ${summary.employees_by_role.MANAGER} | V ${summary.employees_by_role.VOLUNTEER}`,
@@ -64,7 +65,8 @@ export function SummaryCards({ summary }: SummaryCardsProps) {
                className="text-primary"
             />
          ),
-      },
+      }]
+         : []),
       {
          title: 'Estoque crítico',
          value: summary.critical_stock_items,

--- a/src/components/Panel/TableContainer.tsx
+++ b/src/components/Panel/TableContainer.tsx
@@ -44,7 +44,7 @@ export default function TableContainer({
       : [];
 
    return (
-      <div className="bg-white rounded-3xl shadow-md border border-[#4AA1D3] flex flex-col max-h-[calc(100vh-200px)]">
+      <div className="bg-white rounded-3xl shadow-md border border-[#4AA1D3] flex flex-col">
          {/* Header similar ao Jampack */}
          <div className="p-6 pb-4 flex-shrink-0">
             <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 mb-4">
@@ -82,7 +82,7 @@ export default function TableContainer({
             </div>
          </div>
 
-         <div className="flex-1 overflow-auto min-h-0">
+         <div className="overflow-x-auto">
             <table className="w-full border-collapse">
                <thead className="sticky top-0 bg-white z-10">
                   <tr>

--- a/src/components/template/home/Page.tsx
+++ b/src/components/template/home/Page.tsx
@@ -18,6 +18,7 @@ const publicRoutes = ['/', '/about', '/contactUs', '/login'];
 function Page(props: PageProps) {
    const path = usePathname(); // Obtém a pathname da URL
    const isPublicRoute = publicRoutes.includes(path); // Verifica se a rota é pública
+   const isDashboardRoute = path.startsWith('/dashboard');
 
    return (
       <div
@@ -26,21 +27,21 @@ function Page(props: PageProps) {
             background: 'white',
          }}
       >
-         <div className="flex-1 flex flex-col w-screen">
+         <div className="flex-1 flex flex-col w-full">
             {!props.noHeader &&
                (isPublicRoute ? <Header logged={false} /> : null)}
 
-            {path.startsWith('/dashboard') ? (
+            {isDashboardRoute ? (
                <div
-                  className="flex flex-col min-h-screen"
+                  className="flex h-screen flex-col overflow-hidden"
                   style={{
                      background: 'white',
                   }}
                >
                   <Header logged />
-                  <div className="flex-1 flex w-screen">
+                  <div className="flex min-h-0 flex-1 w-full overflow-hidden">
                      <Sidebar />
-                     <div className="flex-1 flex flex-col overflow-y-auto">
+                     <div className="min-w-0 flex-1 flex flex-col overflow-y-auto">
                         <main
                            className={`flex-1 flex flex-col${
                               props.className ?? ''

--- a/src/components/template/manager/Page.tsx
+++ b/src/components/template/manager/Page.tsx
@@ -11,15 +11,15 @@ interface PageProps {
 function Page(props: PageProps) {
    return (
       <div
-         className="flex flex-col min-h-screen"
+         className="flex h-screen flex-col overflow-hidden"
          style={{
             background: 'white',
          }}
       >
          {!props.noHeader && <Header logged />}
-         <div className="flex-1 flex w-screen">
+         <div className="flex min-h-0 flex-1 w-full overflow-hidden">
             <Sidebar />
-            <div className="flex-1 flex flex-col overflow-y-auto">
+            <div className="min-w-0 flex-1 flex flex-col overflow-y-auto">
                <main
                   className={`flex-1 flex flex-col ${props.className ?? ''}`}
                >

--- a/src/components/template/manager/SideBar.tsx
+++ b/src/components/template/manager/SideBar.tsx
@@ -12,9 +12,12 @@ import {
 } from '@phosphor-icons/react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import useAuth from '@/data/hooks/useAuth';
+import { canManageVolunteers } from '@/core/auth/permissions';
 
 export default function Sidebar() {
    const pathname = usePathname();
+   const { user } = useAuth();
    const sidebarTopics = [
       {
          description: 'Dashboard',
@@ -41,15 +44,19 @@ export default function Sidebar() {
          link: '/dashboard/events',
          icon: <CalendarIcon size={24} />,
       },
-      {
-         description: 'Voluntários',
-         link: '/dashboard/volunteers',
-         icon: <IdentificationBadgeIcon size={24} />,
-      },
+      ...(canManageVolunteers(user?.role)
+         ? [
+              {
+                 description: 'Voluntários',
+                 link: '/dashboard/volunteers',
+                 icon: <IdentificationBadgeIcon size={24} />,
+              },
+           ]
+         : []),
    ];
 
    return (
-      <aside className="sidebar-color w-64 h-screen sticky top-0 self-start flex flex-col justify-between p-4 overflow-y-auto">
+      <aside className="sidebar-color h-full w-64 flex-none flex flex-col justify-between p-4 overflow-y-auto">
          <div>
             {sidebarTopics.map((topic, index) => {
                const isActive =

--- a/src/core/auth/permissions.ts
+++ b/src/core/auth/permissions.ts
@@ -1,0 +1,45 @@
+import { VolunteerRole } from '@/core/volunteer/model/IVolunteer';
+
+export function isAdmin(role?: VolunteerRole | string | null) {
+   return role === VolunteerRole.ADMIN;
+}
+
+export function isManager(role?: VolunteerRole | string | null) {
+   return role === VolunteerRole.MANAGER;
+}
+
+export function isVolunteer(role?: VolunteerRole | string | null) {
+   return role === VolunteerRole.VOLUNTEER;
+}
+
+export function canManageVolunteers(role?: VolunteerRole | string | null) {
+   return isAdmin(role) || isManager(role);
+}
+
+export function canDeleteRecords(role?: VolunteerRole | string | null) {
+   return isAdmin(role) || isManager(role);
+}
+
+export function canDeleteEmployees(role?: VolunteerRole | string | null) {
+   return isAdmin(role);
+}
+
+export function canChangeEmployeeRole(role?: VolunteerRole | string | null) {
+   return isAdmin(role);
+}
+
+export function canChangeEmployeePassword(role?: VolunteerRole | string | null) {
+   return isAdmin(role);
+}
+
+export function canPublishEventInstagram(role?: VolunteerRole | string | null) {
+   return isAdmin(role) || isManager(role);
+}
+
+export function canCreateEvents(role?: VolunteerRole | string | null) {
+   return isAdmin(role) || isManager(role);
+}
+
+export function canCancelEvent(role?: VolunteerRole | string | null) {
+   return isAdmin(role) || isManager(role);
+}

--- a/src/core/dashboard/model/IDashboard.ts
+++ b/src/core/dashboard/model/IDashboard.ts
@@ -2,8 +2,8 @@ export type DashboardPeriod = 'month' | 'quarter' | 'semester' | 'year';
 
 export interface IDashboardSummary {
    active_families: number;
-   active_employees: number;
-   employees_by_role: {
+   active_employees?: number;
+   employees_by_role?: {
       ADMIN: number;
       MANAGER: number;
       VOLUNTEER: number;
@@ -81,8 +81,8 @@ export interface IDashboardOverview {
    lists: {
       upcoming_events: IUpcomingEvent[];
       critical_stock: ICriticalStockItem[];
-      recent_donations: IRecentDonation[];
-      recent_families: IRecentFamily[];
+      recent_donations?: IRecentDonation[];
+      recent_families?: IRecentFamily[];
    };
 }
 

--- a/src/core/event/validation/eventSchema.ts
+++ b/src/core/event/validation/eventSchema.ts
@@ -1,4 +1,4 @@
-import { object, string, nativeEnum, ZodType } from 'zod';
+import { coerce, object, string, nativeEnum, ZodType } from 'zod';
 import { EventStatus, IEventForm } from '../model/IEvent';
 import { isValidInstagramUrl, isValidInstagramEmbed } from '@/utils/instagram';
 
@@ -81,10 +81,11 @@ export const eventSchema: ZodType<IEventForm> = object({
          }
       ),
 
-   status: nativeEnum(EventStatus, {
+	   status: nativeEnum(EventStatus, {
       errorMap: () => ({
          message: 'Status inválido. Use SCHEDULED, COMPLETED ou CANCELED',
       }),
-   }),
-   greeting_description: string().optional().default(''),
+	   }),
+   attendance: coerce.number().int().min(0).optional(),
+	   greeting_description: string().optional().default(''),
 });

--- a/src/core/volunteer/model/IVolunteer.ts
+++ b/src/core/volunteer/model/IVolunteer.ts
@@ -2,11 +2,11 @@ export interface IVolunteer {
    id?: string;
    name: string;
    surname: string;
-   birth_date: Date;
+   birth_date: Date | string;
    cpf: string;
    email: string;
    phone: string;
-   password: string;
+   password?: string;
 
    role: VolunteerRole;
 
@@ -15,7 +15,7 @@ export interface IVolunteer {
    neighborhood: string;
    number: string;
    city: string;
-   uf: string;
+   uf?: string;
    state: string;
    complement?: string;
 

--- a/src/data/hooks/employee/useEmployeeMutations.ts
+++ b/src/data/hooks/employee/useEmployeeMutations.ts
@@ -1,0 +1,107 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'react-toastify';
+import { IVolunteer, VolunteerRole } from '@/core/volunteer/model/IVolunteer';
+import {
+   employeeService,
+   EmployeePasswordPayload,
+} from '@/data/services/employeeService';
+import { queryKeys } from '@/data/query/queryKeys';
+
+function useEmployeeInvalidation() {
+   const queryClient = useQueryClient();
+
+   return {
+      invalidateEmployees: () => {
+         queryClient.invalidateQueries({ queryKey: queryKeys.volunteers.all });
+         queryClient.invalidateQueries({ queryKey: queryKeys.resources.roles() });
+      },
+      setEmployee: (id: string, data: unknown) => {
+         queryClient.setQueryData(queryKeys.volunteers.detail(id), data);
+      },
+      removeEmployee: (id: string) => {
+         queryClient.removeQueries({ queryKey: queryKeys.volunteers.detail(id) });
+      },
+   };
+}
+
+export function useEmployeeMutations() {
+   const { invalidateEmployees, setEmployee, removeEmployee } =
+      useEmployeeInvalidation();
+
+   const createEmployee = useMutation({
+      mutationFn: (employee: IVolunteer) => employeeService.createEmployee(employee),
+      onSuccess: (data) => {
+         if (data.data.id) {
+            setEmployee(data.data.id, data);
+         }
+         invalidateEmployees();
+         toast.success('Voluntário cadastrado com sucesso!');
+      },
+      onError: (error) => {
+         toast.error(`Erro ao cadastrar voluntário: ${error.message}`);
+      },
+   });
+
+   const updateBasic = useMutation({
+      mutationFn: ({ id, employee }: { id: string; employee: Partial<IVolunteer> }) =>
+         employeeService.updateBasic(id, employee),
+      onSuccess: (data, variables) => {
+         setEmployee(variables.id, data);
+         invalidateEmployees();
+         toast.success('Voluntário atualizado com sucesso!');
+      },
+      onError: (error) => {
+         toast.error(`Erro ao atualizar voluntário: ${error.message}`);
+      },
+   });
+
+   const updateRole = useMutation({
+      mutationFn: ({ id, role }: { id: string; role: VolunteerRole }) =>
+         employeeService.updateRole(id, role),
+      onSuccess: (data, variables) => {
+         setEmployee(variables.id, data);
+         invalidateEmployees();
+         toast.success('Função atualizada com sucesso!');
+      },
+      onError: (error) => {
+         toast.error(`Erro ao atualizar função: ${error.message}`);
+      },
+   });
+
+   const updatePassword = useMutation({
+      mutationFn: ({
+         id,
+         data,
+      }: {
+         id: string;
+         data: EmployeePasswordPayload;
+      }) => employeeService.updatePassword(id, data),
+      onSuccess: (data, variables) => {
+         setEmployee(variables.id, data);
+         toast.success('Senha atualizada com sucesso!');
+      },
+      onError: (error) => {
+         toast.error(`Erro ao atualizar senha: ${error.message}`);
+      },
+   });
+
+   const deleteEmployee = useMutation({
+      mutationFn: (id: string) => employeeService.deleteEmployee(id),
+      onSuccess: (_, id) => {
+         removeEmployee(id);
+         invalidateEmployees();
+         toast.success('Voluntário desativado com sucesso!');
+      },
+      onError: (error) => {
+         toast.error(`Erro ao desativar voluntário: ${error.message}`);
+      },
+   });
+
+   return {
+      createEmployee,
+      updateBasic,
+      updateRole,
+      updatePassword,
+      deleteEmployee,
+   };
+}

--- a/src/data/hooks/employee/useEmployeeQueries.ts
+++ b/src/data/hooks/employee/useEmployeeQueries.ts
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query';
+import { employeeService } from '@/data/services/employeeService';
+import { queryKeys } from '@/data/query/queryKeys';
+
+export function useEmployees(enabled = true) {
+   return useQuery({
+      queryKey: queryKeys.volunteers.lists(),
+      queryFn: () => employeeService.getEmployees(),
+      enabled,
+      staleTime: 5 * 60 * 1000,
+   });
+}
+
+export function useEmployeeById(id?: string, enabled = true) {
+   return useQuery({
+      queryKey: id ? queryKeys.volunteers.detail(id) : queryKeys.volunteers.details(),
+      queryFn: () => employeeService.getEmployeeById(id!),
+      enabled: enabled && !!id,
+      staleTime: 5 * 60 * 1000,
+   });
+}

--- a/src/data/hooks/useEventMutations.ts
+++ b/src/data/hooks/useEventMutations.ts
@@ -6,6 +6,7 @@ import {
 import { eventService, EventDetailResponse } from '../services/eventService';
 import { queryKeys } from '../query/queryKeys';
 import { IEvent } from '@/core/event';
+import { EventStatus } from '@/core/event/model/IEvent';
 import { toast } from 'react-toastify';
 
 // Hook para criar evento
@@ -100,6 +101,77 @@ export function usePatchEvent(
    });
 }
 
+export function useUpdateEventStatus(
+   options?: UseMutationOptions<
+      EventDetailResponse,
+      Error,
+      { id: string; status: EventStatus }
+   >
+) {
+   const queryClient = useQueryClient();
+
+   return useMutation({
+      mutationFn: ({ id, status }) => eventService.updateEventStatus(id, status),
+      onSuccess: (data, variables) => {
+         queryClient.setQueryData(queryKeys.events.detail(variables.id), data);
+         queryClient.invalidateQueries({ queryKey: queryKeys.events.all });
+         toast.success('Status do evento atualizado com sucesso!');
+      },
+      onError: (error) => {
+         toast.error(`Erro ao atualizar status: ${error.message}`);
+      },
+      ...options,
+   });
+}
+
+export function useUpdateEventAttendance(
+   options?: UseMutationOptions<
+      EventDetailResponse,
+      Error,
+      { id: string; attendance: number }
+   >
+) {
+   const queryClient = useQueryClient();
+
+   return useMutation({
+      mutationFn: ({ id, attendance }) =>
+         eventService.updateEventAttendance(id, attendance),
+      onSuccess: (data, variables) => {
+         queryClient.setQueryData(queryKeys.events.detail(variables.id), data);
+         queryClient.invalidateQueries({ queryKey: queryKeys.events.all });
+         toast.success('Presença do evento atualizada com sucesso!');
+      },
+      onError: (error) => {
+         toast.error(`Erro ao atualizar presença: ${error.message}`);
+      },
+      ...options,
+   });
+}
+
+export function useUpdateEventInstagram(
+   options?: UseMutationOptions<
+      EventDetailResponse,
+      Error,
+      { id: string; embedded_instagram?: string }
+   >
+) {
+   const queryClient = useQueryClient();
+
+   return useMutation({
+      mutationFn: ({ id, embedded_instagram }) =>
+         eventService.updateEventInstagram(id, embedded_instagram),
+      onSuccess: (data, variables) => {
+         queryClient.setQueryData(queryKeys.events.detail(variables.id), data);
+         queryClient.invalidateQueries({ queryKey: queryKeys.events.all });
+         toast.success('Instagram do evento atualizado com sucesso!');
+      },
+      onError: (error) => {
+         toast.error(`Erro ao atualizar Instagram: ${error.message}`);
+      },
+      ...options,
+   });
+}
+
 // Hook para deletar evento
 export function useDeleteEvent(
    options?: UseMutationOptions<void, Error, string>
@@ -126,15 +198,21 @@ export function useDeleteEvent(
 
 // Hook combinado para operações CRUD de eventos
 export function useEventMutations() {
-   const createEvent = useCreateEvent();
-   const updateEvent = useUpdateEvent();
-   const patchEvent = usePatchEvent();
-   const deleteEvent = useDeleteEvent();
+	   const createEvent = useCreateEvent();
+	   const updateEvent = useUpdateEvent();
+	   const patchEvent = usePatchEvent();
+	   const updateEventStatus = useUpdateEventStatus();
+	   const updateEventAttendance = useUpdateEventAttendance();
+	   const updateEventInstagram = useUpdateEventInstagram();
+	   const deleteEvent = useDeleteEvent();
 
    return {
       createEvent,
-      updateEvent,
-      patchEvent,
-      deleteEvent,
-   };
+	      updateEvent,
+	      patchEvent,
+	      updateEventStatus,
+	      updateEventAttendance,
+	      updateEventInstagram,
+	      deleteEvent,
+	   };
 }

--- a/src/data/hooks/useResources.ts
+++ b/src/data/hooks/useResources.ts
@@ -35,17 +35,19 @@ export function useEventStatusResources(
    });
 }
 
-export function useRoleOptions(): {
+export function useRoleOptions(
+   queryOptions?: Omit<UseQueryOptions<RolesApiResponse>, 'queryKey' | 'queryFn'>
+): {
    options: RoleOption[];
    isLoading: boolean;
    isError: boolean;
 } {
-   const { data, isLoading, isError } = useRolesResources();
-   const options = data?.data?.roles?.length
+   const { data, isLoading, isError } = useRolesResources(queryOptions);
+   const roleOptions = data?.data?.roles?.length
       ? data.data.roles
       : FALLBACK_ROLE_OPTIONS;
 
-   return { options, isLoading, isError };
+   return { options: roleOptions, isLoading, isError };
 }
 
 export function useEventStatusOptions(): {

--- a/src/data/services/employeeService.ts
+++ b/src/data/services/employeeService.ts
@@ -1,0 +1,132 @@
+import { IVolunteer, VolunteerRole } from '@/core/volunteer/model/IVolunteer';
+import { BaseDetailResponse, BaseResponse, BaseService } from './baseService';
+
+export interface EmployeeListResponse extends BaseResponse<IVolunteer> {}
+export interface EmployeeDetailResponse extends BaseDetailResponse<IVolunteer> {}
+
+export interface EmployeePasswordPayload {
+   password: string;
+}
+
+export interface OwnPasswordPayload {
+   current_password: string;
+   new_password: string;
+}
+
+function formatBirthDate(value: Date | string) {
+   if (value instanceof Date) {
+      return value.toISOString().slice(0, 10);
+   }
+
+   return value;
+}
+
+function stripUiFields(data: Partial<IVolunteer>) {
+   const {
+      id,
+      created_at,
+      updated_at,
+      logs,
+      uf,
+      password,
+      role,
+      ...payload
+   } = data;
+
+   return {
+      ...payload,
+      birth_date: payload.birth_date
+         ? formatBirthDate(payload.birth_date)
+         : undefined,
+   };
+}
+
+function buildCreatePayload(data: IVolunteer) {
+   const payload = stripUiFields(data);
+
+   return {
+      ...payload,
+      password: data.password,
+      role: data.role,
+   };
+}
+
+class EmployeeService extends BaseService<IVolunteer> {
+   constructor() {
+      super('employees');
+   }
+
+   async getEmployees(): Promise<EmployeeListResponse> {
+      return this.request<EmployeeListResponse>(`/${this.entityPath}`);
+   }
+
+   async getEmployeeById(id: string): Promise<EmployeeDetailResponse> {
+      return this.request<EmployeeDetailResponse>(`/${this.entityPath}/${id}`);
+   }
+
+   async createEmployee(data: IVolunteer): Promise<EmployeeDetailResponse> {
+      return this.request<EmployeeDetailResponse>(`/${this.entityPath}`, {
+         method: 'POST',
+         body: JSON.stringify(buildCreatePayload(data)),
+      });
+   }
+
+   async updateBasic(
+      id: string,
+      data: Partial<IVolunteer>
+   ): Promise<EmployeeDetailResponse> {
+      return this.request<EmployeeDetailResponse>(`/${this.entityPath}/${id}/basic`, {
+         method: 'PUT',
+         body: JSON.stringify(stripUiFields(data)),
+      });
+   }
+
+   async updateRole(
+      id: string,
+      role: VolunteerRole
+   ): Promise<EmployeeDetailResponse> {
+      return this.request<EmployeeDetailResponse>(`/${this.entityPath}/${id}/role`, {
+         method: 'PATCH',
+         body: JSON.stringify({ role }),
+      });
+   }
+
+   async updatePassword(
+      id: string,
+      data: EmployeePasswordPayload
+   ): Promise<EmployeeDetailResponse> {
+      return this.request<EmployeeDetailResponse>(
+         `/${this.entityPath}/${id}/password`,
+         {
+            method: 'PATCH',
+            body: JSON.stringify(data),
+         }
+      );
+   }
+
+   async updateOwnProfile(
+      data: Partial<IVolunteer>
+   ): Promise<EmployeeDetailResponse> {
+      return this.request<EmployeeDetailResponse>(`/${this.entityPath}/me`, {
+         method: 'PATCH',
+         body: JSON.stringify(stripUiFields(data)),
+      });
+   }
+
+   async updateOwnPassword(
+      data: OwnPasswordPayload
+   ): Promise<EmployeeDetailResponse> {
+      return this.request<EmployeeDetailResponse>(`/${this.entityPath}/me/password`, {
+         method: 'PATCH',
+         body: JSON.stringify(data),
+      });
+   }
+
+   async deleteEmployee(id: string): Promise<void> {
+      return this.request<void>(`/${this.entityPath}/${id}`, {
+         method: 'DELETE',
+      });
+   }
+}
+
+export const employeeService = new EmployeeService();

--- a/src/data/services/eventService.ts
+++ b/src/data/services/eventService.ts
@@ -45,6 +45,12 @@ const PUBLIC_EVENT_REQUEST: ApiRequestBehavior = {
    ignoreStatuses: [404],
 };
 
+function stripBasicEventFields(event: Partial<IEvent>) {
+   const { status, attendance, embedded_instagram, ...basicEvent } = event;
+
+   return basicEvent;
+}
+
 class EventService extends BaseService<IEvent> {
    constructor() {
       super('events');
@@ -140,14 +146,50 @@ class EventService extends BaseService<IEvent> {
    }
 
    // Atualizar evento
-   async updateEvent(
+	   async updateEvent(
+	      id: string,
+	      event: Partial<IEvent>
+	   ): Promise<EventDetailResponse> {
+	      return this.request<EventDetailResponse>(`/${this.entityPath}/${id}`, {
+	         method: 'PUT',
+	         body: JSON.stringify(stripBasicEventFields(event)),
+	      });
+	   }
+
+   async updateEventStatus(
       id: string,
-      event: Partial<IEvent>
+      status: EventStatus
    ): Promise<EventDetailResponse> {
-      return this.request<EventDetailResponse>(`/${this.entityPath}/${id}`, {
-         method: 'PUT',
-         body: JSON.stringify(event),
+      return this.request<EventDetailResponse>(`/${this.entityPath}/${id}/status`, {
+         method: 'PATCH',
+         body: JSON.stringify({ status }),
       });
+   }
+
+   async updateEventAttendance(
+      id: string,
+      attendance: number
+   ): Promise<EventDetailResponse> {
+      return this.request<EventDetailResponse>(
+         `/${this.entityPath}/${id}/attendance`,
+         {
+            method: 'PATCH',
+            body: JSON.stringify({ attendance }),
+         }
+      );
+   }
+
+   async updateEventInstagram(
+      id: string,
+      embedded_instagram?: string
+   ): Promise<EventDetailResponse> {
+      return this.request<EventDetailResponse>(
+         `/${this.entityPath}/${id}/instagram`,
+         {
+            method: 'PATCH',
+            body: JSON.stringify({ embedded_instagram }),
+         }
+      );
    }
 
    // Atualizar evento parcialmente

--- a/src/data/store/authStore.ts
+++ b/src/data/store/authStore.ts
@@ -56,6 +56,7 @@ function getSession(): Session {
         email: payload.email,
         name: payload.name,
         surname: payload.surname,
+        role: payload.role,
       },
     };
   } catch (error) {


### PR DESCRIPTION
## Summary

- Stores the authenticated user role from the JWT and adds frontend permission helpers.
- Updates dashboard navigation, volunteer management, events, dashboard rendering, and destructive actions to reflect role permissions.
- Replaces volunteer mocks with real employee API calls for listing, creation, editing, role changes, and password changes.
- Fixes dashboard shell/sidebar height and removes nested vertical scrolling from families and donations tables.

## Impact

The frontend now mirrors backend permissions for a cleaner user experience while leaving authorization enforcement to the API. Admin users see full controls, managers see operational controls, and volunteers see only allowed navigation and actions.

## Validation

- `yarn build`
- `git diff --check`